### PR TITLE
marketplace -> platform

### DIFF
--- a/app/.env.common
+++ b/app/.env.common
@@ -3,8 +3,8 @@
 
 PORT=3333
 STREAMR_URL=http://localhost/streamr-core/
-MARKETPLACE_URL_ORIGIN=http://localhost
-MARKETPLACE_BASE_URL=/marketplace
+PLATFORM_ORIGIN_URL=http://localhost
+PLATFORM_BASE_PATH=/platform
 STREAMR_API_URL=http://localhost/streamr-core/api/v1
 STREAMR_WS_URL=ws://localhost:8890/api/v1/ws
 GOOGLE_ANALYTICS_ID=DO_NOT_REMOVE

--- a/app/src/history.js
+++ b/app/src/history.js
@@ -3,5 +3,5 @@
 import createHistory from 'history/createBrowserHistory'
 
 export default createHistory({
-    basename: process.env.MARKETPLACE_BASE_URL,
+    basename: process.env.PLATFORM_BASE_PATH,
 })

--- a/app/src/marketplace/flowtype/global-types.js
+++ b/app/src/marketplace/flowtype/global-types.js
@@ -5,8 +5,8 @@ declare class process {
         NODE_ENV: string,
         STREAMR_API_URL: string,
         STREAMR_URL: string,
-        MARKETPLACE_BASE_URL: string,
-        MARKETPLACE_URL_ORIGIN: string,
+        PLATFORM_BASE_PATH: string,
+        PLATFORM_ORIGIN_URL: string,
         STREAMR_WS_URL: string,
         GOOGLE_ANALYTICS_ID: string,
         [key: string]: ?string

--- a/app/src/marketplace/utils/login.js
+++ b/app/src/marketplace/utils/login.js
@@ -4,7 +4,7 @@ import links from '../../links'
 import { formatExternalUrl, formatPath } from './url'
 
 export const getLoginUrl = (...localPath: Array<string>) => {
-    const redirectPath = formatExternalUrl(process.env.MARKETPLACE_URL_ORIGIN, process.env.MARKETPLACE_BASE_URL, 'login', 'external', {
+    const redirectPath = formatExternalUrl(process.env.PLATFORM_ORIGIN_URL, process.env.PLATFORM_BASE_PATH, 'login', 'external', {
         redirect: formatPath(...localPath, '/'), // this ensures trailing slash
     })
     return formatExternalUrl(links.login, {

--- a/app/src/userpages/flowtype/global-types.js
+++ b/app/src/userpages/flowtype/global-types.js
@@ -4,8 +4,8 @@ declare class process {
     static env: {
         STREAMR_API_URL: string,
         STREAMR_URL: string,
-        MARKETPLACE_BASE_URL: string,
-        MARKETPLACE_URL_ORIGIN: string,
+        PLATFORM_BASE_PATH: string,
+        PLATFORM_ORIGIN_URL: string,
         STREAMR_WS_URL: string,
         GOOGLE_ANALYTICS_ID: string,
         [key: string]: ?string

--- a/app/test/unit/modules/editProduct/services.test.js
+++ b/app/test/unit/modules/editProduct/services.test.js
@@ -18,7 +18,7 @@ describe('editProduct - services', () => {
     })
 
     it('puts product', async () => {
-        process.env.STREAMR_API_URL = 'TEST_MARKETPLACE_API_URL'
+        process.env.STREAMR_API_URL = 'TEST_API_URL'
         const data = cloneDeep(existingProduct)
         const expectedResult = cloneDeep(existingProduct)
         expectedResult.pricePerSecond = '1.898e-14'
@@ -38,7 +38,7 @@ describe('editProduct - services', () => {
     })
 
     it('posts product', async () => {
-        process.env.STREAMR_API_URL = 'TEST_MARKETPLACE_API_URL'
+        process.env.STREAMR_API_URL = 'TEST_API_URL'
         const data = cloneDeep(existingProduct)
         const expectedResult = cloneDeep(existingProduct)
         expectedResult.pricePerSecond = '1.898e-14'
@@ -58,7 +58,7 @@ describe('editProduct - services', () => {
     })
 
     it('posts image', async () => {
-        process.env.STREAMR_API_URL = 'TEST_MARKETPLACE_API_URL'
+        process.env.STREAMR_API_URL = 'TEST_API_URL'
         const data = cloneDeep(existingProduct)
         const expectedResult = cloneDeep(existingProduct)
         expectedResult.pricePerSecond = '1.898e-14'

--- a/app/test/unit/modules/user/actions.test.js
+++ b/app/test/unit/modules/user/actions.test.js
@@ -8,20 +8,16 @@ import * as services from '$mp/modules/user/services'
 
 describe('user - actions', () => {
     let sandbox
-    let oldMarketplaceApiUrl
     let oldStreamrApiUrl
 
     beforeEach(() => {
-        oldMarketplaceApiUrl = process.env.MARKETPLACE_API_URL
         oldStreamrApiUrl = process.env.STREAMR_API_URL
-        process.env.MARKETPLACE_API_URL = ''
         process.env.STREAMR_API_URL = ''
         sandbox = sinon.createSandbox()
     })
 
     afterEach(() => {
         sandbox.restore()
-        process.env.MARKETPLACE_API_URL = oldMarketplaceApiUrl
         process.env.STREAMR_API_URL = oldStreamrApiUrl
     })
 

--- a/app/test/unit/modules/user/services.test.js
+++ b/app/test/unit/modules/user/services.test.js
@@ -8,7 +8,6 @@ import * as productUtils from '$mp/utils/product'
 describe('user - services', () => {
     let sandbox
     let dateNowSpy
-    let oldMarketplaceApiUrl
     let oldStreamrApiUrl
     const DATE_NOW = 1337
 
@@ -23,16 +22,13 @@ describe('user - services', () => {
 
     beforeEach(() => {
         sandbox = sinon.createSandbox()
-        oldMarketplaceApiUrl = process.env.MARKETPLACE_API_URL
         oldStreamrApiUrl = process.env.STREAMR_API_URL
-        process.env.MARKETPLACE_API_URL = ''
         process.env.STREAMR_API_URL = ''
         moxios.install()
     })
 
     afterEach(() => {
         sandbox.restore()
-        process.env.MARKETPLACE_API_URL = oldMarketplaceApiUrl
         process.env.STREAMR_API_URL = oldStreamrApiUrl
         moxios.uninstall()
     })

--- a/app/test/unit/utils/login.test.js
+++ b/app/test/unit/utils/login.test.js
@@ -6,25 +6,25 @@ import links from '$app/src/links'
 describe('login utils', () => {
     describe('getLoginUrl', () => {
         let oldLoginLink
-        let oldUrlOrigin
-        let oldBaseUrl
+        let oldOriginUrl
+        let oldBasePath
 
         beforeEach(() => {
             oldLoginLink = links.login
-            oldUrlOrigin = process.env.MARKETPLACE_URL_ORIGIN
-            oldBaseUrl = process.env.MARKETPLACE_BASE_URL
+            oldOriginUrl = process.env.PLATFORM_ORIGIN_URL
+            oldBasePath = process.env.PLATFORM_BASE_PATH
         })
 
         afterEach(() => {
             links.login = oldLoginLink
-            process.env.MARKETPLACE_URL_ORIGIN = oldUrlOrigin
-            process.env.MARKETPLACE_BASE_URL = oldBaseUrl
+            process.env.PLATFORM_ORIGIN_URL = oldOriginUrl
+            process.env.PLATFORM_BASE_PATH = oldBasePath
         })
 
         it('forms login url correctly from one arg', () => {
             links.login = 'http://streamr.test/login'
-            process.env.MARKETPLACE_URL_ORIGIN = 'http://marketplace.test'
-            process.env.MARKETPLACE_BASE_URL = '/marketplace'
+            process.env.PLATFORM_ORIGIN_URL = 'http://marketplace.test'
+            process.env.PLATFORM_BASE_PATH = '/marketplace'
             assert.equal(
                 all.getLoginUrl('/test/path'),
                 'http://streamr.test/login?redirect=' +
@@ -34,8 +34,8 @@ describe('login utils', () => {
 
         it('forms login url correctly from multiple args', () => {
             links.login = 'http://streamr.test/login'
-            process.env.MARKETPLACE_URL_ORIGIN = 'http://marketplace.test'
-            process.env.MARKETPLACE_BASE_URL = '/marketplace'
+            process.env.PLATFORM_ORIGIN_URL = 'http://marketplace.test'
+            process.env.PLATFORM_BASE_PATH = '/marketplace'
             assert.equal(
                 all.getLoginUrl('test', 'path'),
                 'http://streamr.test/login?redirect=' +

--- a/app/test/unit/web3/web3Provider.test.js
+++ b/app/test/unit/web3/web3Provider.test.js
@@ -86,19 +86,19 @@ describe('web3Provider', () => {
             global.web3 = Web3
             global.web3.currentProvider = new StreamrWeb3.providers.HttpProvider('http://boop:1337')
             const web3 = getWeb3()
-            assert(web3.currentProvider.host === 'http://boop:1337')
+            assert.equal(web3.currentProvider.host, 'http://boop:1337')
         })
         it('must return the web3 object with the window.ethereum provider if it is available/defined', () => {
             // permissioned metamask provider injection scenario
             global.ethereum = new StreamrWeb3.providers.HttpProvider('http://vitalik:300')
             const web3 = getWeb3()
-            assert(web3.currentProvider.host === 'http://vitalik:300')
+            assert.equal(web3.currentProvider.host, 'http://vitalik:300')
         })
     })
     describe('getPublicWeb3', () => {
         it('must return web3 with the public provider', () => {
             const web3 = getPublicWeb3()
-            assert(web3.currentProvider.host === 'http://localhost:8545')
+            assert.equal(web3.currentProvider.host, 'http://localhost:8545')
         })
     })
 })

--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -24,7 +24,7 @@ const root = path.resolve(__dirname)
 const dotenvPlugin = StreamrDotenvPlugin(path.resolve(root, '.env.common'), path.resolve(root, '.env'), isProduction())
 const gitRevisionPlugin = new GitRevisionPlugin()
 
-const publicPath = process.env.MARKETPLACE_BASE_URL || '/'
+const publicPath = process.env.PLATFORM_BASE_PATH || '/'
 
 const dist = path.resolve(root, 'dist')
 


### PR DESCRIPTION
Necessary tweaks and appropriate renames to get the platform dev environment running under `/platform` rather than `/marketplace`, using the nginx proxy settings in this PR: https://github.com/streamr-dev/streamr-docker-dev/pull/19 

web3provider test fails for me, but it also failed prior to this PR. 