### PR TITLE
 Fixed broken link to profile

### DIFF
--- a/app/src/marketplace/components/Nav/index.jsx
+++ b/app/src/marketplace/components/Nav/index.jsx
@@ -114,7 +114,7 @@ class Nav extends React.Component<Props> {
                         )}
                         align="left"
                     >
-                        <a href={formatPath(links.profile)}>
+                        <a href={links.profile}>
                             <Translate value="general.profile" />
                         </a>
                         <a href={links.logout} onClick={logout}>


### PR DESCRIPTION
Link to user profile in Nav menu is broken.

`formatPath` is actually mangling all `http:` prefixed urls by adding a `/` to the start of the path e.g. `http://localhost/streamr-core/profile/edit` becomes: `http://localhost/platform/http://localhost/streamr-core/profile/edit`. This issue is currently being hidden when using `NavLink`/`Link` wrappers which seem to clean up the leading `/`, but was a problem for the profile link which was using a raw `<a href>`. There may be similar issues in other parts of the app. Not sure if the issue is specific to the dev environment.

----

Going forward, we should probably get rid of the need for components to wrap things in `formatPath`/ `formatExternalUrl` APIs and centralise all route processing out of `links.js`, or similar. The API for dynamic/parameterised paths could be functions instead of strings e.g. `links.product(productId, { query })`. API routes the same. Everything the same.