### PR TITLE
[PLATFORM-118] Add max_old_space_size flag to build command

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.jsx",
   "scripts": {
     "start": "webpack-dev-server --hot",
-    "build": "webpack",
+    "build": "node --max_old_space_size=4096 ./node_modules/.bin/webpack",
     "test": "jest ./test/* ./src/userpages/tests/*",
     "flow": "flow",
     "flow-stop": "flow stop",


### PR DESCRIPTION
Production build fails in `UglifyJSPlugin` with option `sourceMaps: true`, this seems to be an issue with Webpack and large codebase. Here are some discussions around it:

https://github.com/webpack/webpack/issues/6389
https://github.com/webpack-contrib/uglifyjs-webpack-plugin/issues/272

Increasing the heap memory size with `max-old-space-size` flag seems to be the recommended fix.