### PR TITLE
[PLATFORM-29] Rudimentary Module Search/Add

### DIFF
--- a/app/src/editor/components/Canvas.jsx
+++ b/app/src/editor/components/Canvas.jsx
@@ -88,13 +88,13 @@ export default DragDropContext(HTML5Backend)(class Canvas extends React.Componen
     }
 
     render() {
-        const { className, ...props } = this.props
+        const { className, canvas } = this.props
 
         return (
             <div className={cx(styles.Canvas, className)}>
                 <CanvasElements
-                    key={props.canvas.id}
-                    {...props}
+                    key={canvas.id}
+                    canvas={canvas}
                     api={this.api}
                     {...this.api.module}
                 />

--- a/app/src/editor/components/Module.jsx
+++ b/app/src/editor/components/Module.jsx
@@ -54,8 +54,6 @@ class CanvasModule extends React.Component {
                 style={{
                     top: layout.position.top,
                     left: layout.position.left,
-                    width: layout.width,
-                    height: layout.height,
                 }}
             >
                 <div className={styles.moduleHeader}>

--- a/app/src/editor/components/Port.jsx
+++ b/app/src/editor/components/Port.jsx
@@ -82,9 +82,8 @@ class Port extends React.PureComponent {
         if (isParam) {
             /* add input for params */
             portContent.push((
-                <div className={styles.portValueContainer}>
+                <div key={`${port.id}.value`} className={styles.portValueContainer}>
                     <input
-                        key={`${port.id}.value`}
                         className={styles.portValue}
                         value={this.state.value}
                         disabled={!!port.connected}
@@ -99,7 +98,7 @@ class Port extends React.PureComponent {
         } else if (isInput) {
             /* placeholder div for consistent icon vertical alignment */
             portContent.push((
-                <div className={styles.portValueContainer}>
+                <div key={`${port.id}.value`} className={styles.portValueContainer}>
                     <div
                         className={styles.portValue}
                     />

--- a/app/src/editor/components/Search.jsx
+++ b/app/src/editor/components/Search.jsx
@@ -1,0 +1,85 @@
+import React from 'react'
+import startCase from 'lodash/startCase'
+
+import * as API from '../../userpages/utils/api'
+import styles from './Search.pcss'
+
+const apiUrl = `${process.env.STREAMR_URL}/module/jsonGetModuleTree`
+
+function indexModules(modules = [], path = [], index = []) {
+    modules.forEach((m) => {
+        if (m.metadata.canAdd) {
+            index.push({
+                id: m.metadata.id,
+                name: m.data,
+                path: path.join(', '),
+            })
+        }
+        if (m.children && m.children.length) {
+            indexModules(m.children, path.concat(m.data), index)
+        }
+    })
+    return index
+}
+
+function searchModules(moduleIndex, search) {
+    search = search.trim().toLowerCase()
+    if (!search) { return moduleIndex }
+    const nameMatches = moduleIndex.filter((m) => (
+        m.name.toLowerCase().includes(search)
+    ))
+    const found = new Set(nameMatches.map(({ id }) => id))
+    const pathMatches = moduleIndex.filter((m) => (
+        m.path.toLowerCase().includes(search) && !found.has(m.id)
+    ))
+    return nameMatches.concat(pathMatches)
+}
+
+export default class ModuleSearch extends React.PureComponent {
+    state = {
+        search: '',
+        modules: [],
+    }
+
+    componentDidMount() {
+        this.load()
+    }
+
+    async load() {
+        const modules = await API.get(apiUrl)
+        this.setState({
+            modules: indexModules(modules),
+        })
+    }
+
+    onChange = (event) => {
+        const { value } = event.currentTarget
+        this.setState({ search: value })
+    }
+
+    onSelect = (id) => {
+        this.props.showModuleSearch(false)
+        this.props.addModule({ id })
+    }
+
+    render() {
+        return (
+            <div className={styles.Search} hidden={!this.props.show}>
+                <div className={styles.Header}>
+                    <button onClick={() => this.props.showModuleSearch(false)}>X</button>
+                </div>
+                <div className={styles.Input}>
+                    <input placeholder="Search or select a module" value={this.state.search} onChange={this.onChange} />
+                </div>
+                <div role="listbox" className={styles.Content}>
+                    {searchModules(this.state.modules, this.state.search).map((m) => (
+                        /* eslint-disable-next-line */
+                        <div role="option" key={m.id} onClick={() => this.onSelect(m.id)}>
+                            {startCase(m.name)}
+                        </div>
+                    ))}
+                </div>
+            </div>
+        )
+    }
+}

--- a/app/src/editor/components/Search.pcss
+++ b/app/src/editor/components/Search.pcss
@@ -1,0 +1,62 @@
+.Search {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: white;
+  min-height: 33vh;
+  min-width: 25vw;
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: 40px auto 1fr;
+  z-index: 1;
+  border: 1px solid #EFEFEF;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.Search .Header {
+  background: #F8F8F8;
+  border-bottom: 1px solid #EFEFEF;
+}
+
+.Search .Header button {
+  appearance: none;
+  display: block;
+  width: 32px;
+  height: 32px;
+  border: none;
+  color: #A3A3A3;
+  margin-left: auto;
+  background: none;
+}
+
+.Search .Input input {
+  font-size: 14px;
+  line-height: 1;
+  text-align: left;
+  letter-spacing: 0;
+  border: none;
+  border-bottom: 1px solid #EFEFEF;
+  box-sizing: border-box;
+  padding: 16px 24px;
+  width: 100%;
+}
+
+.Search .Content {
+  color: #525252;
+  font-size: 12px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-weight: 500;
+  text-align: left;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  line-height: 32px;
+  max-height: 300px;
+  overflow: auto;
+}
+
+.Search .Content > * {
+  padding: 10px 24px;
+  border-bottom: 1px solid #EFEFEF;
+}

--- a/app/src/editor/components/Toolbar.jsx
+++ b/app/src/editor/components/Toolbar.jsx
@@ -32,7 +32,7 @@ export default class CanvasToolbar extends React.Component {
                     </R.UncontrolledButtonDropdown>
                     <R.Button onClick={() => API.put(`${apiUrl}/${canvas.id}`, canvas)}>Save</R.Button>
                 </R.ButtonGroup>
-                <R.Button>+</R.Button>
+                <R.Button onClick={() => this.props.showModuleSearch()}>+</R.Button>
                 <div>
                     <R.Button color="success">Start</R.Button>
                     <R.UncontrolledDropdown>

--- a/app/src/editor/index.jsx
+++ b/app/src/editor/index.jsx
@@ -3,14 +3,19 @@ import { connect } from 'react-redux'
 import cloneDeep from 'lodash/cloneDeep'
 
 import { getCanvas } from '../userpages/modules/canvas/actions'
+import * as API from '../userpages/utils/api'
 import Canvas from './components/Canvas'
 import CanvasToolbar from './components/Toolbar'
+import ModuleSearch from './components/Search'
 
 import styles from './index.pcss'
+
+const getModuleURL = `${process.env.STREAMR_URL}/module/jsonGetModule`
 
 class CanvasEdit extends Component {
     state = {
         canvas: undefined,
+        showModuleSearch: false,
     }
 
     static getDerivedStateFromProps(props, state) {
@@ -23,12 +28,38 @@ class CanvasEdit extends Component {
         }
         return {
             canvas: cloneDeep(props.canvas),
+            showModuleSearch: false,
         }
     }
 
     setCanvas = (fn) => {
         this.setState(({ canvas }) => ({
             canvas: fn(canvas),
+        }))
+    }
+
+    showModuleSearch = (show = true) => {
+        this.setState({
+            showModuleSearch: !!show,
+        })
+    }
+
+    addModule = async ({ id }) => {
+        const form = new FormData()
+        form.append('id', id)
+        const module = await API.post(getModuleURL, form)
+        module.hash = Date.now()
+        module.layout = {
+            position: {
+                top: 0,
+                left: 0,
+            },
+            width: '100px',
+            height: '100px',
+        }
+        this.setCanvas((canvas) => ({
+            ...canvas,
+            modules: canvas.modules.concat(module),
         }))
     }
 
@@ -41,9 +72,15 @@ class CanvasEdit extends Component {
                     setCanvas={this.setCanvas}
                 />
                 <CanvasToolbar
+                    showModuleSearch={this.showModuleSearch}
                     className={styles.CanvasToolbar}
                     canvas={this.state.canvas}
                     setCanvas={this.setCanvas}
+                />
+                <ModuleSearch
+                    show={this.state.showModuleSearch}
+                    addModule={this.addModule}
+                    showModuleSearch={this.showModuleSearch}
                 />
             </div>
         )


### PR DESCRIPTION
Very rough first pass. Just need *some* system of adding modules in order to create the canvas configurations for testing other canvas features.

![search-add-module](https://user-images.githubusercontent.com/43438/46457665-ce74cf00-c7e5-11e8-9dac-42300dd02670.gif)

### Known Caveats

* No autofocus of search input on open
* Search doesn't show by default for empty canvases
* No keyboard navigation of search results
* No esc to close modal behaviour
* No by-category browsing, only search by name
* No width or height stored in layout
* Module "hash" function isn't sequential
