### PR TITLE
[PLATFORM-61] Add FileUpload component

### DIFF
--- a/app/src/marketplace/components/ComponentLibrary/index.jsx
+++ b/app/src/marketplace/components/ComponentLibrary/index.jsx
@@ -80,9 +80,12 @@ const ComponentLibrary = () => (
                         component={<span className={styles.title}>Drag a file here or click to browse</span>}
                         dropTargetComponent={<span className={styles.title}>Drop here!</span>}
                         dragOverComponent={<span className={styles.title}>Yay, just drop it!</span>}
-                        onFilesAccepted={(files) => console.error(files)}
+                        onFilesAccepted={(files) => console.log(files)} // eslint-disable-line no-console
                         onError={(error) => console.error(error)}
                         acceptMime={['image/jpeg', 'image/png']}
+                        maxFileSizeInMB={5}
+                        multiple={false}
+                        disablePreview
                     />
                 </Col>
             </Row>

--- a/app/src/shared/components/FileUpload/fileUpload.pcss
+++ b/app/src/shared/components/FileUpload/fileUpload.pcss
@@ -1,5 +1,6 @@
 .dropzone {
-  width: 100%;
   overflow: hidden;
   position: relative;
+  display: inline-block;
+  width: auto;
 }

--- a/app/src/shared/components/FileUpload/index.jsx
+++ b/app/src/shared/components/FileUpload/index.jsx
@@ -22,6 +22,7 @@ type Props = {
     onFilesAccepted: (Array<File>) => void,
     onError?: (error: FileUploadError) => void,
     acceptMime: Array<string>,
+    maxFileSizeInMB: number,
 }
 
 type State = {
@@ -29,9 +30,7 @@ type State = {
     isDragOver: boolean,
 }
 
-const MaxFileSize = 5242880
-
-class ImageUpload extends Component<Props, State> {
+class FileUpload extends Component<Props, State> {
     constructor() {
         super()
         window.addEventListener('dragenter', this.onWindowDragEnter)
@@ -59,10 +58,10 @@ class ImageUpload extends Component<Props, State> {
     }
 
     onDropRejected = ([file]: any) => {
-        const { onError, acceptMime } = this.props
+        const { onError, acceptMime, maxFileSizeInMB } = this.props
 
         if (onError) {
-            if (file.size > MaxFileSize) {
+            if (file.size > maxFileSizeInMB) {
                 onError(fileUploadErrors.FILE_TOO_LARGE)
             }
 
@@ -123,24 +122,32 @@ class ImageUpload extends Component<Props, State> {
     }
 
     render() {
+        const {
+            component,
+            dropTargetComponent,
+            dragOverComponent,
+            onFilesAccepted,
+            onError,
+            acceptMime,
+            maxFileSizeInMB,
+            ...rest
+        } = this.props
+
         return (
             <Dropzone
-                multiple={false}
                 className={styles.dropzone}
                 onDrop={this.onDrop}
                 onDropRejected={this.onDropRejected}
                 onDragOver={this.onDragOver}
                 onDragLeave={this.onDragLeave}
                 accept={this.props.acceptMime.join(', ')}
-                maxSize={MaxFileSize}
-                disablePreview
+                maxSize={this.props.maxFileSizeInMB * 1024 * 1024}
+                {...rest}
             >
-                <div>
-                    {this.renderChildren()}
-                </div>
+                {this.renderChildren()}
             </Dropzone>
         )
     }
 }
 
-export default ImageUpload
+export default FileUpload


### PR DESCRIPTION
Add Dropzone wrapper that can be used for file uploads. Does not handle upload per se but will return selected files through `onFilesAccepted` prop.

When a (window level) drag operation is noticed, the component will render `dropTargetComponent` to allow showing a highlighted drop target.