### PR TITLE
Improve webpack initial build speed

### DIFF
--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -45,12 +45,18 @@ module.exports = {
                 enforce: 'pre',
                 use: [{
                     loader: 'eslint-loader',
+                    options: {
+                        cache: !isProduction(),
+                    },
                 }],
             },
             {
                 test: /.jsx?$/,
                 loader: 'babel-loader',
                 include: [path.resolve(root, 'src'), path.resolve(root, 'scripts'), /node_modules\/stringify-object/, /node_modules\/query-string/],
+                options: {
+                    cacheDirectory: !isProduction(),
+                },
             },
             // Images are put to <BASE_URL>/images
             {


### PR DESCRIPTION
This appears to reduce the time taken to do the initial webpack build i.e. improves the speed of `npm start`, not the speed to rebuild after changes.

#### Caching Disabled

* Initial build: ~65s
* Build again: ~65s

#### Caching Enabled (this PR)

* Initial build: ~65s
* Build again: ~33s

Note:  Build times above are with `USERPAGES=on`.

Due to the caveat below, caching is currently only enabled for non-production builds.
 
----

##### Caveat

On rare occasions in the past I have seen this type of caching get borked up and refuse to update for some reason. If you suspect this is happening just `rm -rf app/node_modules/.cache`. This blows away both `babel-loader` and `eslint-loader` caches.