### PR TITLE
Refactor dotenv loading

### DIFF
--- a/app/scripts/dotenv.js
+++ b/app/scripts/dotenv.js
@@ -1,32 +1,43 @@
-const webpack = require('webpack')
 const dotenv = require('dotenv')
 const dotenvSafe = require('dotenv-safe')
+const path = require('path')
+const isProduction = require('./isProduction')
 
 /**
- * Sets dotenv file variables into process.env (if not inProduction)
- * and returns a webpack plugin that sets then to the process.env in browser as well
- *
- * @param commonDotenvPath {string} path to common dotenv file, eg. .env.common
- * @param localDotenvPath {string} path to private dotenv file, eg. .env
- * @param isProduction {boolean}
- * @returns {webpack.EnvironmentPlugin}
+ * Loads .env.common into process.env in non-production environment.
+ * @returns An array of loaded keys.
  */
+const loadCommonDotenv = () => {
+    const envPath = path.resolve(__dirname, '../.env.common')
+    const vars = dotenvSafe.config({
+        example: envPath,
+        path: !isProduction() ? envPath : null,
+    }).required
 
-const getDotenvPlugin = (commonDotenvPath, localDotenvPath, isProduction) => {
-    const localDotenv = !isProduction ? dotenv.config({
-        example: null,
-        path: localDotenvPath,
-    }) : {}
-
-    const commonDotenv = dotenvSafe.config({
-        example: commonDotenvPath,
-        path: !isProduction ? commonDotenvPath : null,
-    })
-
-    return new webpack.EnvironmentPlugin([
-        ...Object.keys(commonDotenv.required || {}),
-        ...Object.keys(localDotenv.parsed || {}),
-    ])
+    return Object.keys(vars || {})
 }
 
-module.exports = getDotenvPlugin
+/**
+ * Loads .env into process.env in non-production environment.
+ * @returns An array of loaded keys.
+ */
+const loadLocalDotenv = () => {
+    const envPath = path.resolve(__dirname, '../.env')
+    const vars = !isProduction() ? dotenv.config({
+        example: null,
+        path: envPath,
+    }).parsed : {}
+
+    return Object.keys(vars || {})
+}
+
+/**
+ * Loads .env.common and .env into process.env in non-production environment.
+ * @returns An array of loaded keys.
+ */
+const loadDotenv = () => ([
+    ...loadCommonDotenv(),
+    ...loadLocalDotenv(),
+])
+
+module.exports = loadDotenv

--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -13,13 +13,12 @@ const cssProcessor = require('cssnano')
 
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const GitRevisionPlugin = require('git-revision-webpack-plugin')
-const StreamrDotenvPlugin = require('./scripts/dotenv.js')
+const dotenv = require('./scripts/dotenv.js')
 
 const isProduction = require('./scripts/isProduction')
 
 const root = path.resolve(__dirname)
 
-const dotenvPlugin = StreamrDotenvPlugin(path.resolve(root, '.env.common'), path.resolve(root, '.env'), isProduction())
 const gitRevisionPlugin = new GitRevisionPlugin()
 
 const publicPath = process.env.PLATFORM_BASE_PATH || '/'
@@ -132,7 +131,7 @@ module.exports = {
                 'src/**/*.(p|s)css',
             ],
         }),
-        dotenvPlugin,
+        new webpack.EnvironmentPlugin(dotenv()),
     ].concat(isProduction() ? [
         // Production plugins
         new webpack.optimize.OccurrenceOrderPlugin(),


### PR DESCRIPTION
`script/dotenv.js` is no longer a webpack plugin. Its purpose now is to get the variables loaded
into process.env. That’s it. The new version returns a set of loaded keys and can easily be used for webpack’s EnvironmentPlugin.

_(This PR replaced #84. Difference: this one doesn't touch tests.)_