### PR TITLE
Loading .env, option 2 (force local .env)

### DIFF
--- a/app/scripts/dotenv.js
+++ b/app/scripts/dotenv.js
@@ -1,6 +1,5 @@
-const dotenv = require('dotenv')
-const dotenvSafe = require('dotenv-safe')
 const path = require('path')
+const dotenvSafe = require('dotenv-safe')
 const isProduction = require('./isProduction')
 
 /**
@@ -8,25 +7,13 @@ const isProduction = require('./isProduction')
  * @returns An array of loaded keys.
  */
 const loadCommonDotenv = () => {
-    const envPath = path.resolve(__dirname, '../.env.common')
-    const vars = dotenvSafe.config({
-        example: envPath,
-        path: !isProduction() ? envPath : null,
-    }).required
-
-    return Object.keys(vars || {})
-}
-
-/**
- * Loads .env into process.env in non-production environment.
- * @returns An array of loaded keys.
- */
-const loadLocalDotenv = () => {
+    const examplePath = path.resolve(__dirname, '../.env.common')
     const envPath = path.resolve(__dirname, '../.env')
-    const vars = !isProduction() ? dotenv.config({
-        example: null,
-        path: envPath,
-    }).parsed : {}
+    const vars = dotenvSafe.config({
+        example: examplePath,
+        path: !isProduction() ? envPath : null,
+        allowEmptyValues: true,
+    }).required
 
     return Object.keys(vars || {})
 }
@@ -37,7 +24,6 @@ const loadLocalDotenv = () => {
  */
 const loadDotenv = () => ([
     ...loadCommonDotenv(),
-    ...loadLocalDotenv(),
 ])
 
 module.exports = loadDotenv


### PR DESCRIPTION
Overriding `.env` values does not work by default (https://github.com/motdotla/dotenv#options):

> We will never modify any environment variables that have already been set. In particular, if there is a variable in your .env file which collides with one that already exists in your environment, then that variable will be skipped. 
(From: https://github.com/motdotla/dotenv#options)

This PR forces everyone to create a local `.env` to match the `env.common`. It will give an error like this if those values are not defined:

```
MissingEnvVarsError: The following variables were defined in /Users/juhah/projects/streamr-dev/streamr-platform/app/.env.common but are not present in the environment:
  PORT, STREAMR_URL, PLATFORM_ORIGIN_URL, PLATFORM_BASE_PATH, STREAMR_API_URL, STREAMR_WS_URL, GOOGLE_ANALYTICS_ID, USERPAGES
Make sure to add them to .env or directly to the environment.
```

Which one you prefer, this or option 1: #91 