### PR TITLE
Remove NoEmitOnErrorsPlugin

### DIFF
--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -167,7 +167,6 @@ module.exports = {
     ] : [
         // Dev plugins
         new FlowBabelWebpackPlugin(),
-        new webpack.NoEmitOnErrorsPlugin(),
         new WebpackNotifierPlugin(),
         new webpack.EnvironmentPlugin({
             GIT_VERSION: gitRevisionPlugin.version(),


### PR DESCRIPTION
The plugin I've removed in this PR is only enabled in development and prevents webpack from building if there are any errors, including errors from eslint.

This is very annoying during development as it forces you to waste time repeatedly reformatting/unreformatting things just to add some temporary logging statements. With this change the errors will still be reported as normal, but webpack will at least permit the app to build. This should not change production/CI build behaviour.