### PR TITLE
[PLATFORM-180] ReferenceError: ga is not defined in staging

### DIFF
--- a/app/src/index.html
+++ b/app/src/index.html
@@ -36,19 +36,19 @@
     <script src="https://cdn.polyfill.io/v2/polyfill.min.js" data-react-helmet="true"></script>
     <style data-react-helmet="true">@-ms-viewport { width: device-width; }</style>
 
-    <!--
+    <%/*
         Global site tag (gtag.js) - Google Analytics
-        Is added here so that it can be read without rendering js on the page
-    -->
+        Is added here so that it can be read without rendering js on the page.
+        We also set 'send_page_view': false so that the initial page load wouldn't send page view, otherwise it would get sent twice
+    */%>
     <script async src="https://www.googletagmanager.com/gtag/js?id=<%= gaId %>"></script>
     <script>
+        window.ga=window.ga||function(){ (ga.q=ga.q||[]).push(arguments)};ga.l=+new Date
         window.dataLayer = window.dataLayer || []
-        function gtag(){
-            dataLayer.push(arguments)
-        }
+        function gtag(){dataLayer.push(arguments)}
         gtag('js', new Date())
         gtag('config', '<%= gaId %>', {
-            'send_page_view': false, // we only want to send page views in GoogleAnalyticsTracker, otherwise the initial page load would get sent twice
+            'send_page_view': false,
         })
     </script>
 </head>

--- a/app/src/marketplace/components/GoogleAnalyticsTracker/index.jsx
+++ b/app/src/marketplace/components/GoogleAnalyticsTracker/index.jsx
@@ -4,8 +4,6 @@ import { Component } from 'react'
 import { withRouter, type Location } from 'react-router-dom'
 import ReactGA from 'react-ga'
 
-declare var ga: (type: string, ...args: any[]) => void
-
 const gaId = process.env.GOOGLE_ANALYTICS_ID
 
 type Props = {
@@ -15,8 +13,8 @@ type Props = {
 class GoogleAnalyticsTracker extends Component<Props> {
     constructor(props: Props) {
         super(props)
-        // Must call ga('create', gaId) instead of ReactGA.initialize(gaId) since we don't want to inject the ga script to DOM again
-        ga('create', gaId)
+        // Must call window.ga('create', gaId) instead of ReactGA.initialize(gaId) since we don't want to inject the ga script to DOM again
+        window.ga('create', gaId)
         this.logPageview(this.props.location.pathname)
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,36 @@
 {
-  "lockfileVersion": 1
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "big.js": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
+    },
+    "emojis-list": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+    },
+    "json5": {
+      "version": "0.5.1",
+      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+    },
+    "loader-utils": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+      "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+      "requires": {
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0"
+      }
+    },
+    "querystringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
+      "integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw=="
+    }
+  }
 }


### PR DESCRIPTION
Added a buffer for `window.ga` so that it can be used before it has loaded (and then the event gets sent after the loading). Tested by throttling `analytics.google.com`