### PR TITLE
Sort canvases by last updated.

### DIFF
--- a/app/src/userpages/modules/canvas/actions.js
+++ b/app/src/userpages/modules/canvas/actions.js
@@ -66,7 +66,7 @@ export const getCanvases = () => (dispatch: Function) => {
     return get(apiUrl, {
         params: {
             adhoc: false,
-            sort: 'dateCreated',
+            sortBy: 'lastUpdated',
             order: 'desc',
         },
     })

--- a/app/src/userpages/tests/modules/canvas/actions.test.js
+++ b/app/src/userpages/tests/modules/canvas/actions.test.js
@@ -30,7 +30,7 @@ describe('Canvas actions', () => {
             expect(request.url).toMatch(/canvases/)
             expect(request.config.params).toEqual({
                 adhoc: false,
-                sort: 'dateCreated',
+                sortBy: 'lastUpdated',
                 order: 'desc',
             })
             request.respondWith({
@@ -71,7 +71,7 @@ describe('Canvas actions', () => {
             expect(request.url).toMatch(/canvases/)
             expect(request.config.params).toEqual({
                 adhoc: false,
-                sort: 'dateCreated',
+                sortBy: 'lastUpdated',
                 order: 'desc',
             })
             request.respondWith({


### PR DESCRIPTION
Not sure what the current sort order is, if there's any, but I have a lot of trouble finding stuff while testing. This sorts canvases by their last updated time on the ~~frontend~~ backend.