### PR TITLE
Link to the old Login, Sign up and Logout pages

### DIFF
--- a/app/src/marketplace/components/App/index.jsx
+++ b/app/src/marketplace/components/App/index.jsx
@@ -11,12 +11,8 @@ import ProductPage from '../../containers/ProductPage'
 import StreamPreviewPage from '../../containers/StreamPreviewPage'
 import EditProductPage from '../../containers/EditProductPage'
 import Products from '../../containers/Products'
-import LoginPage from '$auth/containers/LoginPage'
+import LoginPage from '../../containers/LoginPage'
 import LogoutPage from '$auth/containers/LogoutPage'
-import SignupPage from '$auth/containers/SignupPage'
-import ForgotPasswordPage from '$auth/containers/ForgotPasswordPage'
-import ResetPasswordPage from '$auth/containers/ResetPasswordPage'
-import RegisterPage from '$auth/containers/RegisterPage'
 import AccountPage from '../../containers/AccountPage'
 import ComponentLibrary from '../../components/ComponentLibrary'
 // TODO: Use '../../../userpages' when userpages are production-ready. #userpages-on-demand
@@ -27,7 +23,7 @@ import Docs from '../../../docs/current'
 import ModalRoot from '../../containers/ModalRoot'
 import Notifications from '../../containers/Notifications'
 import { formatPath } from '$shared/utils/url'
-import { userIsAuthenticated } from '../../utils/auth'
+import { userIsAuthenticated, userIsNotAuthenticated } from '../../utils/auth'
 import links from '../../../links'
 import history from '../../../history'
 import '../../../analytics'
@@ -44,6 +40,7 @@ import routes from '$routes'
 const AccountAuth = userIsAuthenticated(AccountPage)
 const CreateProductAuth = userIsAuthenticated(EditProductPage)
 const EditProductAuth = userIsAuthenticated(EditProductPage)
+const LoginRedirect = userIsNotAuthenticated(LoginPage)
 
 // Other components
 const ProductPurchasePage = (props) => <ProductPage overlayPurchaseDialog {...props} />
@@ -59,22 +56,14 @@ const App = () => (
                 <LocaleSetter />
                 <ModalManager />
                 <Switch>
-                    <Route exact path={routes.login()} component={LoginPage} />
                     <Route exact path={routes.logout()} component={LogoutPage} />
-                    <Route path={routes.signUp()} component={SignupPage} />
-                    <Route path={routes.forgotPassword()} component={ForgotPasswordPage} />
-                    <Route path={routes.resetPassword()} component={ResetPasswordPage} />
-                    <Route exact path={routes.register()} component={RegisterPage} />
-                    <Redirect from="/login/auth" to={routes.login()} />
-                    <Redirect from="/register/register" to={routes.register()} />
-                    <Redirect from="/register/resetPassword" to={routes.resetPassword()} />
-                    <Redirect from="/register/forgotPassword" to={routes.forgotPassword()} />
                     <Route path={routes.editProduct()} component={EditProductAuth} />
                     <Route path={formatPath(links.products, ':id', 'purchase')} component={ProductPurchasePage} />
                     <Route path={formatPath(links.products, ':id', 'publish')} component={ProductPublishPage} />
                     <Route path={formatPath(links.products, ':id', 'streamPreview', ':streamId')} component={StreamPreviewPage} />
                     <Route path={formatPath(links.products, ':id')} component={ProductPage} />
                     <Route exact path={links.main} component={Products} />
+                    <Route exact path={formatPath(links.internalLogin, ':type?')} component={LoginRedirect} />
                     <Route exact path={formatPath(links.account, ':tab(purchases|products)')} component={AccountAuth} />
                     <Redirect exact from={links.account} to={formatPath(links.account, 'purchases')} />
                     <Route exact path={links.createProduct} component={CreateProductAuth} />

--- a/app/src/marketplace/components/LoginPage/index.jsx
+++ b/app/src/marketplace/components/LoginPage/index.jsx
@@ -1,0 +1,28 @@
+// @flow
+
+import React from 'react'
+import type { Match } from 'react-router-dom'
+
+export type Props = {
+    match: Match,
+    endExternalLogin: () => void,
+}
+
+class LoginPage extends React.Component<Props> {
+    componentDidMount() {
+        const { match, endExternalLogin } = this.props
+
+        if (match.params.type === 'external') {
+            // After ending the external login 'redux-auth-wrapper'
+            // picks up the query parameter 'redirect' and redirects
+            // to given page automatically.
+            endExternalLogin()
+        }
+    }
+
+    render() {
+        return null
+    }
+}
+
+export default LoginPage

--- a/app/src/marketplace/components/Nav/index.jsx
+++ b/app/src/marketplace/components/Nav/index.jsx
@@ -84,12 +84,12 @@ class Nav extends React.Component<Props> {
                     </NavLink>
                 )}
                 {!currentUser && (
-                    <NavLink mobile to={routes.login()}>
+                    <NavLink mobile href={this.getLoginLink()}>
                         <Translate value="general.signIn" />
                     </NavLink>
                 )}
                 {!currentUser && (
-                    <NavLink mobile outline to={routes.signUp()}>
+                    <NavLink mobile outline href={routes.oldSignUp()}>
                         <Translate value="general.signUp" />
                     </NavLink>
                 )}
@@ -124,12 +124,12 @@ class Nav extends React.Component<Props> {
                     </NavDropdown>
                 )}
                 {!currentUser && (
-                    <NavLink desktop to={routes.login()}>
+                    <NavLink desktop href={this.getLoginLink()}>
                         <Translate value="general.signIn" />
                     </NavLink>
                 )}
                 {!currentUser && (
-                    <NavLink desktop outline to={routes.signUp()}>
+                    <NavLink desktop outline href={routes.oldSignUp()}>
                         <Translate value="general.signUp" />
                     </NavLink>
                 )}

--- a/app/src/marketplace/containers/LoginPage/index.jsx
+++ b/app/src/marketplace/containers/LoginPage/index.jsx
@@ -1,0 +1,21 @@
+// @flow
+
+import { connect } from 'react-redux'
+
+import LoginPage from '../../components/LoginPage'
+import { endExternalLogin } from '$shared/modules/user/actions'
+
+type StateProps = {
+}
+
+type DispatchProps = {
+    endExternalLogin: () => void,
+}
+
+const mapStateToProps = (): StateProps => ({})
+
+const mapDispatchToProps = (dispatch: Function): DispatchProps => ({
+    endExternalLogin: () => dispatch(endExternalLogin()),
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(LoginPage)

--- a/app/src/marketplace/containers/ProductPage/index.jsx
+++ b/app/src/marketplace/containers/ProductPage/index.jsx
@@ -21,6 +21,7 @@ import { getRelatedProducts } from '../../modules/relatedProducts/actions'
 import { PURCHASE, PUBLISH } from '../../utils/modals'
 import { showModal } from '../../modules/modals/actions'
 import { isPaidProduct } from '../../utils/product'
+import { doExternalLogin } from '../../utils/auth'
 import BackButton from '../../components/Buttons/Back'
 
 import {
@@ -36,7 +37,6 @@ import {
 } from '../../modules/product/selectors'
 import { selectUserData } from '$shared/modules/user/selectors'
 import links from '../../../links'
-import routes from '$routes'
 import { selectRelatedProductList } from '../../modules/relatedProducts/selectors'
 
 export type OwnProps = {
@@ -301,11 +301,7 @@ export const mapDispatchToProps = (dispatch: Function): DispatchProps => ({
         if (isLoggedIn) {
             dispatch(purchaseProduct())
         } else {
-            dispatch(replace(routes.login({
-                redirect: routes.product({
-                    id,
-                }),
-            })))
+            doExternalLogin(formatPath(links.products, id))
         }
     },
     showPurchaseDialog: (product: Product) => dispatch(showModal(PURCHASE, {

--- a/app/src/marketplace/utils/auth.js
+++ b/app/src/marketplace/utils/auth.js
@@ -1,19 +1,33 @@
 // @flow
 
-import { connectedRouterRedirect } from 'redux-auth-wrapper/history4/redirect'
+import { connectedRouterRedirect, connectedReduxRedirect } from 'redux-auth-wrapper/history4/redirect'
 import locationHelperBuilder from 'redux-auth-wrapper/history4/locationHelper'
+import queryString from 'query-string'
 
-import { selectUserData, selectFetchingUserData } from '$shared/modules/user/selectors'
-import routes from '$routes'
+import { selectUserData, selectFetchingExternalLogin, selectFetchingUserData } from '$shared/modules/user/selectors'
+import { startExternalLogin } from '$shared/modules/user/actions'
 
-export const userIsAuthenticated = connectedRouterRedirect({
-    redirectPath: routes.login(),
-    authenticatingSelector: (state) => selectFetchingUserData(state),
+import { getLoginUrl } from './login'
+
+export const doExternalLogin = (accessedPath: string) => {
+    // Use browser's native redirection for external redirect
+    // Use .replace to skip recording a needless step which would break native Back function
+    window.location.replace(getLoginUrl(accessedPath))
+}
+
+export const userIsAuthenticated = connectedReduxRedirect({
+    redirectPath: 'NOT_USED_BUT_MUST_PROVIDE',
+    authenticatingSelector: (state) => selectFetchingUserData(state) || selectFetchingExternalLogin(state),
     // If selector is true, wrapper will not redirect
     // For example let's check that state contains user data
     authenticatedSelector: (state) => selectUserData(state) !== null,
     // A nice display name for this check
     wrapperDisplayName: 'UserIsAuthenticated',
+    redirectAction: (newLoc) => (dispatch) => {
+        const accessedPath = queryString.parse(newLoc.search).redirect
+        dispatch(startExternalLogin())
+        doExternalLogin(accessedPath)
+    },
 })
 
 const locationHelper = locationHelperBuilder({})

--- a/app/src/marketplace/utils/login.js
+++ b/app/src/marketplace/utils/login.js
@@ -3,6 +3,8 @@
 import links from '../../links'
 import { formatExternalUrl, formatPath } from '$shared/utils/url'
 
+// TODO: With the new auth stuff we should *not* need this function at all. Let's remove
+//       it when the migration is complete. — Mariusz
 export const getLoginUrl = (...localPath: Array<string>) => {
     const redirectPath = formatExternalUrl(process.env.PLATFORM_ORIGIN_URL, process.env.PLATFORM_BASE_PATH, 'login', 'external', {
         redirect: formatPath(...localPath, '/'), // this ensures trailing slash

--- a/app/src/routes/definitions.json
+++ b/app/src/routes/definitions.json
@@ -1,4 +1,6 @@
 {
+    "oldLogin": "<streamr>/login/auth",
+    "oldSignUp": "<streamr>/register/signup",
     "account": "/account/:tab(purchases|products)?",
     "createProduct": "/account/products/create",
     "editProduct": "/products/:id/edit",
@@ -10,7 +12,7 @@
     "externalResetPassword": "<streamr>/auth/resetPassword",
     "externalSignUp": "<streamr>/auth/signup",
     "forgotPassword": "/forgotPassword",
-    "login": "/login",
+    "login": "/login/:type?",
     "logout": "/logout",
     "marketplace": "/",
     "product": "/products/:id",

--- a/app/src/shared/modules/user/actions.js
+++ b/app/src/shared/modules/user/actions.js
@@ -1,7 +1,6 @@
 // @flow
 
 import { createAction } from 'redux-actions'
-import { replace } from 'react-router-redux'
 
 import type { ErrorInUi, ReduxActionCreator } from '$shared/flowtype/common-types'
 import type { ApiKey, User, PasswordUpdate } from '$shared/flowtype/user-types'
@@ -41,8 +40,6 @@ import {
 } from './constants'
 import routes from '$routes'
 
-// export const logout: ReduxActionCreator = createAction(LOGOUT)
-
 // Logout
 export const logoutRequest: ReduxActionCreator = createAction(LOGOUT_REQUEST)
 export const logoutSuccess: ReduxActionCreator = createAction(LOGOUT_SUCCESS)
@@ -56,7 +53,10 @@ export const logout = () => (dispatch: Function) => {
         .logout()
         .then(() => {
             dispatch(logoutSuccess())
-            dispatch(replace(routes.root()))
+            window.location.replace(routes.externalLogout())
+            // NOTE: Replace the above line with the following when the backend
+            //       auth stuff is fixed. — Mariusz
+            // dispatch(replace(routes.root()))
         }, (error) => {
             dispatch(logoutFailure(error))
         })

--- a/app/src/shared/modules/user/constants.js
+++ b/app/src/shared/modules/user/constants.js
@@ -16,6 +16,8 @@ export const LOGOUT_REQUEST: string = 'marketplace/user/LOGOUT_REQUEST'
 export const LOGOUT_SUCCESS: string = 'marketplace/user/LOGOUT_SUCCESS'
 export const LOGOUT_FAILURE: string = 'marketplace/user/LOGOUT_FAILURE'
 
+// TODO: Let's get rid of the following 2 consts after the migration to the new
+//       auth stuff is complete. — Mariusz
 export const EXTERNAL_LOGIN_START: string = 'marketplace/user/EXTERNAL_LOGIN_START'
 export const EXTERNAL_LOGIN_END: string = 'marketplace/user/EXTERNAL_LOGIN_END'
 

--- a/app/src/shared/modules/user/services.js
+++ b/app/src/shared/modules/user/services.js
@@ -6,7 +6,7 @@ import { get, post } from '$shared/utils/api'
 import { formatApiUrl } from '$shared/utils/url'
 import type { ApiResult } from '$shared/flowtype/common-types'
 import type { User, IntegrationKey, ApiKey, PasswordUpdate } from '$shared/flowtype/user-types'
-import routes from '$routes'
+// import routes from '$routes'
 
 export const getMyKeys = (): ApiResult<Array<ApiKey>> => get(formatApiUrl('users', 'me', 'keys', {
     noCache: Date.now(),
@@ -60,8 +60,14 @@ export const postPasswordUpdate = (passwordUpdate: PasswordUpdate, userInputs?: 
 /**
  * Sends a logout request.
  */
-export const logout = (): Promise<any> => get(routes.externalLogout(), {
-    headers: {
-        'Content-Type': 'application/json',
-    },
-})
+export const logout = (): Promise<any> => (
+    // get(routes.externalLogout(), {
+    //     headers: {
+    //         'Content-Type': 'application/json',
+    //     },
+    // })
+    // NOTE: Replace the following line with the code above when the backend
+    //       auth stuff is fixed. — Mariusz
+    Promise.resolve('')
+)
+

--- a/app/src/shared/utils/url.js
+++ b/app/src/shared/utils/url.js
@@ -9,7 +9,7 @@ import { I18n } from 'react-redux-i18n'
  * @param args URL parts, incl. strings, numbers, and/or objects
  */
 const getUrlParts = (args: Array<string | number | Object>): Array<string> => (
-    args.filter((arg) => !isObject(arg)).map((arg) => arg.toString())
+    args.filter((arg) => !isObject(arg) && arg != null).map((arg) => arg.toString())
 )
 
 /**

--- a/app/test/unit/containers/ProductPage/ProductPage.test.jsx
+++ b/app/test/unit/containers/ProductPage/ProductPage.test.jsx
@@ -9,6 +9,7 @@ import * as productActions from '$mp/modules/product/actions'
 import * as relatedProductsActions from '$mp/modules/relatedProducts/actions'
 import * as modalActions from '$mp/modules/modals/actions'
 import * as urlUtils from '$shared/utils/url'
+import * as authUtils from '$mp/utils/auth'
 
 import ProductPageComponent from '$mp/components/ProductPage'
 import NotFoundPage from '$mp/components/NotFoundPage'
@@ -150,6 +151,7 @@ describe('ProductPage', () => {
     it('maps actions to props', () => {
         const dispatchStub = sandbox.stub().callsFake((action) => action)
         const formatPathStub = sandbox.stub(urlUtils, 'formatPath')
+        const doExternalLoginStub = sandbox.stub(authUtils, 'doExternalLogin')
         const getProductByIdStub = sandbox.stub(productActions, 'getProductById')
         const getProductSubscriptionStub = sandbox.stub(productActions, 'getProductSubscription')
         const purchaseProductStub = sandbox.stub(productActions, 'purchaseProduct')
@@ -177,7 +179,7 @@ describe('ProductPage', () => {
         })
         actions.getRelatedProducts(product.id)
 
-        expect(dispatchStub.callCount).toEqual(11)
+        expect(dispatchStub.callCount).toEqual(10)
 
         expect(getProductByIdStub.calledOnce).toEqual(true)
         expect(getProductByIdStub.calledWith(product.id)).toEqual(true)
@@ -188,10 +190,11 @@ describe('ProductPage', () => {
         expect(getProductSubscriptionStub.calledOnce).toEqual(true)
         expect(getProductSubscriptionStub.calledWith(product.id)).toEqual(true)
 
-        expect(formatPathStub.callCount).toEqual(1)
+        expect(formatPathStub.callCount).toEqual(2)
         expect(formatPathStub.calledWith('/products', product.id)).toEqual(true)
 
         expect(purchaseProductStub.calledOnce).toEqual(true)
+        sinon.assert.calledOnce(doExternalLoginStub)
 
         expect(getRelatedProductsStub.callCount).toEqual(1)
         expect(getRelatedProductsStub.calledWith(product.id)).toEqual(true)

--- a/app/test/unit/modules/user/actions.test.js
+++ b/app/test/unit/modules/user/actions.test.js
@@ -1,7 +1,7 @@
 import assert from 'assert-diff'
 import sinon from 'sinon'
 import mockStore from '$testUtils/mockStoreProvider'
-import { CALL_HISTORY_METHOD } from 'react-router-redux'
+// import { CALL_HISTORY_METHOD } from 'react-router-redux'
 
 import * as actions from '$shared/modules/user/actions'
 import * as constants from '$shared/modules/user/constants'
@@ -115,6 +115,7 @@ describe('user - actions', () => {
         it('calls services.getMyKeys, logs out if there are errors', async () => {
             const error = new Error('error')
             const serviceStub = sandbox.stub(services, 'getMyKeys').callsFake(() => Promise.reject(error))
+            const windowReplaceStub = sandbox.stub(window.location, 'replace')
 
             const store = mockStore()
             await store.dispatch(actions.getApiKeys())
@@ -132,8 +133,14 @@ describe('user - actions', () => {
                 {
                     type: constants.LOGOUT_REQUEST,
                 },
+                // NOTE: Remove the following when the real (async) logout action gets called, i.e. when
+                //       the backend auth stuff is fixed and the code here cleaned up. — Mariusz
+                {
+                    type: constants.LOGOUT_SUCCESS,
+                },
             ]
 
+            sinon.assert.calledWithMatch(windowReplaceStub, /\/logout$/)
             assert.deepStrictEqual(store.getActions(), expectedActions)
         })
     })
@@ -274,6 +281,7 @@ describe('user - actions', () => {
     describe('logout', () => {
         it('calls services.logout and handles error', async () => {
             const serviceStub = sandbox.stub(services, 'logout').callsFake(() => Promise.resolve())
+            const windowReplaceStub = sandbox.stub(window.location, 'replace')
             const store = mockStore()
 
             await store.dispatch(actions.logout())
@@ -286,17 +294,18 @@ describe('user - actions', () => {
                 {
                     type: constants.LOGOUT_SUCCESS,
                 },
-                {
-                    type: CALL_HISTORY_METHOD,
-                    payload: {
-                        method: 'replace',
-                        args: [
-                            '/',
-                        ],
-                    },
-                },
+                // NOTE: Uncomment the following when the backend auth stuff is fixed. — Mariusz
+                // {
+                //     type: CALL_HISTORY_METHOD,
+                //     payload: {
+                //         method: 'replace',
+                //         args: [
+                //             '/',
+                //         ],
+                //     },
+                // },
             ]
-
+            sinon.assert.calledWithMatch(windowReplaceStub, /\/logout$/)
             assert.deepStrictEqual(store.getActions(), expectedActions)
         })
     })

--- a/app/test/unit/modules/user/services.test.js
+++ b/app/test/unit/modules/user/services.test.js
@@ -142,7 +142,8 @@ describe('user - services', () => {
     })
 
     describe('logout', () => {
-        it('logs the user out', async (done) => {
+        // TODO: Change `xit` to `it` when using the local auth pages again. – Mariusz
+        xit('logs the user out', async (done) => {
             moxios.wait(() => {
                 const request = moxios.requests.mostRecent()
                 request.respondWith({
@@ -155,6 +156,12 @@ describe('user - services', () => {
                 done()
             })
 
+            const result = await services.logout()
+            assert.deepStrictEqual(result, '')
+        })
+
+        // TODO: Remove the following example when using the local auth pages. – Mariusz
+        it('logs the user out (the old way, kinda)', async () => {
             const result = await services.logout()
             assert.deepStrictEqual(result, '')
         })


### PR DESCRIPTION
After a struggle with CORS and other auth-related _platform vs. backend_ issues I'm re-linking the login page, signup page, and logout to E&E. The "new" code is still in the repo, all pretty much prepared to be used when the issues are fixed, but for the time being (deployment) we're using the old setup. I also kept changes within a single commit – aiming for an easy re-revert.

Guys, please throw an eye in the browser, focus on links, how they work – log in, log out, go to signup page. All should work nicely. Cheers! :)