### PR TITLE
[FRONT-1933] Add collect all button

### DIFF
--- a/src/hooks/operators.tsx
+++ b/src/hooks/operators.tsx
@@ -585,8 +585,8 @@ export function useCollectEarnings() {
     const { fetch: fetchUncollectedEarnings } = useUncollectedEarningsStore()
 
     return useCallback(
-        (params: { chainId: number; sponsorshipId: string; operatorId: string }) => {
-            const { chainId, sponsorshipId, operatorId } = params
+        (params: { chainId: number; sponsorshipIds: string[]; operatorId: string }) => {
+            const { chainId, sponsorshipIds, operatorId } = params
 
             void (async () => {
                 try {
@@ -606,7 +606,7 @@ export function useCollectEarnings() {
                         return
                     }
 
-                    await collectEarnings(chainId, sponsorshipId, operatorId, {
+                    await collectEarnings(chainId, sponsorshipIds, operatorId, {
                         onReceipt: ({ blockNumber }) =>
                             waitForIndexedBlock(chainId, blockNumber),
                     })

--- a/src/pages/OperatorPage/SponsorshipTable.tsx
+++ b/src/pages/OperatorPage/SponsorshipTable.tsx
@@ -1,0 +1,205 @@
+import React from 'react'
+import moment from 'moment'
+import styled from 'styled-components'
+import { SponsorshipDecimals } from '~/components/Decimals'
+import Spinner from '~/components/Spinner'
+import { FundedUntilCell, StreamIdCell } from '~/components/Table'
+import { Tooltip, TooltipIconWrap } from '~/components/Tooltip'
+import { Operator } from '~/parsers/Operator'
+import { ScrollTable } from '~/shared/components/ScrollTable/ScrollTable'
+import SvgIcon from '~/shared/components/SvgIcon'
+import { Route as R, routeOptions } from '~/utils/routes'
+import {
+    useCanCollectEarningsCallback,
+    useUncollectedEarnings,
+} from '~/shared/stores/uncollectedEarnings'
+import { useCollectEarnings } from '~/hooks/operators'
+import { useEditSponsorshipFunding } from '~/hooks/sponsorships'
+import { Button } from '~/components/Button'
+import { useCurrentChainId, useCurrentChainSymbolicName } from '~/utils/chains'
+
+export function SponsorshipTable({
+    operator,
+    isController,
+}: {
+    operator: Operator
+    isController: boolean
+}) {
+    const canCollect = useCanCollectEarningsCallback()
+
+    const editSponsorshipFunding = useEditSponsorshipFunding()
+
+    const collectEarnings = useCollectEarnings()
+
+    const currentChainId = useCurrentChainId()
+
+    const chainName = useCurrentChainSymbolicName()
+
+    const allSponsorshipIds = operator.stakes.map(({ sponsorshipId }) => sponsorshipId)
+
+    const canCollectAllEarnings = allSponsorshipIds.every((sponsorshipId) =>
+        canCollect(operator.id, sponsorshipId),
+    )
+
+    return (
+        <ScrollTable
+            elements={operator.stakes}
+            columns={[
+                {
+                    displayName: 'Stream ID',
+                    valueMapper: ({ streamId }) => <StreamIdCell streamId={streamId} />,
+                    align: 'start',
+                    isSticky: true,
+                    key: 'streamId',
+                },
+                {
+                    displayName: 'Staked',
+                    valueMapper: (element) => {
+                        const minimumStakeReachTime = moment(
+                            element.joinedAt.getTime() +
+                                element.minimumStakingPeriodSeconds * 1000,
+                        )
+
+                        return (
+                            <>
+                                <SponsorshipDecimals abbr amount={element.amountWei} />
+                                {minimumStakeReachTime.isAfter(Date.now()) && (
+                                    <Tooltip
+                                        content={
+                                            <>
+                                                Minimum stake period:{' '}
+                                                {minimumStakeReachTime.fromNow(true)} left
+                                            </>
+                                        }
+                                    >
+                                        <TooltipIconWrap
+                                            className="ml-1"
+                                            $color="#ADADAD"
+                                            $svgSize={{
+                                                width: '18px',
+                                                height: '18px',
+                                            }}
+                                        >
+                                            <SvgIcon name="lockClosed" />
+                                        </TooltipIconWrap>
+                                    </Tooltip>
+                                )}
+                            </>
+                        )
+                    },
+                    align: 'start',
+                    isSticky: false,
+                    key: 'staked',
+                },
+                {
+                    displayName: 'APY',
+                    valueMapper: (element) =>
+                        `${element.spotAPY.multipliedBy(100).toFixed(0)}%`,
+                    align: 'start',
+                    isSticky: false,
+                    key: 'apy',
+                },
+                {
+                    displayName: 'Funded until',
+                    valueMapper: (element) => (
+                        <FundedUntilCell
+                            projectedInsolvencyAt={element.projectedInsolvencyAt}
+                            remainingBalance={element.remainingWei}
+                        />
+                    ),
+                    align: 'start',
+                    isSticky: false,
+                    key: 'fundedUntil',
+                },
+                {
+                    displayName: 'Uncollected earnings',
+                    valueMapper: (element) => (
+                        <UncollectedEarnings
+                            operatorId={operator.id}
+                            sponsorshipId={element.sponsorshipId}
+                        />
+                    ),
+                    align: 'end',
+                    isSticky: false,
+                    key: 'earnings',
+                },
+            ]}
+            linkMapper={({ sponsorshipId: id }) =>
+                R.sponsorship(id, routeOptions(chainName))
+            }
+            actions={[
+                (element) => ({
+                    displayName: 'Edit',
+                    disabled: !isController,
+                    async callback() {
+                        if (!operator) {
+                            return
+                        }
+
+                        editSponsorshipFunding({
+                            chainId: currentChainId,
+                            sponsorshipOrSponsorshipId: element.sponsorshipId,
+                            operator,
+                        })
+                    },
+                }),
+                (element) => ({
+                    displayName: 'Collect earnings',
+                    callback() {
+                        if (!operator.id) {
+                            return
+                        }
+
+                        collectEarnings({
+                            chainId: currentChainId,
+                            operatorId: operator.id,
+                            sponsorshipIds: [element.sponsorshipId],
+                        })
+                    },
+                    disabled: !canCollect(operator.id, element.sponsorshipId),
+                }),
+            ]}
+            footerComponent={
+                canCollectAllEarnings && (
+                    <Footer>
+                        <Button
+                            kind="secondary"
+                            onClick={async () => {
+                                collectEarnings({
+                                    chainId: currentChainId,
+                                    operatorId: operator.id,
+                                    sponsorshipIds: allSponsorshipIds,
+                                })
+                            }}
+                        >
+                            Collect all
+                        </Button>
+                    </Footer>
+                )
+            }
+        />
+    )
+}
+
+const Footer = styled.div`
+    display: flex;
+    justify-content: right;
+    padding: 32px;
+    gap: 10px;
+`
+
+function UncollectedEarnings({
+    operatorId,
+    sponsorshipId,
+}: {
+    operatorId: string | undefined
+    sponsorshipId: string
+}) {
+    const value = useUncollectedEarnings(operatorId, sponsorshipId)
+
+    return typeof value !== 'undefined' ? (
+        <SponsorshipDecimals abbr amount={value?.uncollectedEarnings || 0n} />
+    ) : (
+        <Spinner color="blue" />
+    )
+}

--- a/src/services/sponsorships.ts
+++ b/src/services/sponsorships.ts
@@ -343,7 +343,7 @@ export async function getEarningsForSponsorships(
 
 export async function collectEarnings(
     chainId: number,
-    sponsorshipId: string,
+    sponsorshipIds: string[],
     operatorAddress: string,
     { onReceipt }: CallableOptions = {},
 ): Promise<void> {
@@ -359,21 +359,8 @@ export async function collectEarnings(
 
     await toastedOperation('Collect earnings', async () => {
         await call(contract, 'withdrawEarningsFromSponsorships', {
-            args: [[sponsorshipId]],
+            args: [sponsorshipIds],
             onReceipt,
         })
-
-        /**
-         * @todo The following rate updating logic does not belong here! Move
-         * it outside and call after `collectEarnings` (this util) calls.
-         */
-
-        /**
-         * Update uncollected earnings because the rate of change will change
-         * along with stake amount.
-         */
-        const { fetch: updateEarnings } = useUncollectedEarningsStore.getState()
-
-        await updateEarnings(chainId, operatorAddress)
     })
 }


### PR DESCRIPTION
I added a new `Collect all` button to sponsorship listing footer on operator page.

PS. While on it, I also extracted sponsorship table on operator page into a new component `SponsorshipTable` to keep things separated.