### PR TITLE
[FRONT-1679] Keep view parameters in URL

### DIFF
--- a/src/components/ActionBars/NetworkActionBar.tsx
+++ b/src/components/ActionBars/NetworkActionBar.tsx
@@ -56,6 +56,7 @@ type Props = {
     searchEnabled: boolean
     placeholder?: string
     onSearch?: (term: string) => void
+    searchValue?: string
     leftSideContent?: ReactNode
     rightSideContent?: ReactNode
 }
@@ -63,6 +64,7 @@ type Props = {
 export const NetworkActionBar: FunctionComponent<Props> = ({
     searchEnabled,
     onSearch,
+    searchValue,
     placeholder,
     leftSideContent,
     rightSideContent,
@@ -72,7 +74,11 @@ export const NetworkActionBar: FunctionComponent<Props> = ({
             <div
                 className={'search-bar-wrap ' + (!searchEnabled ? 'search-disabled' : '')}
             >
-                <SearchBar onChange={onSearch} placeholder={placeholder} />
+                <SearchBar
+                    onChange={onSearch}
+                    placeholder={placeholder}
+                    value={searchValue}
+                />
             </div>
             {(leftSideContent || rightSideContent) && (
                 <div className="action-content-wrap">

--- a/src/hooks/useUrlParams.ts
+++ b/src/hooks/useUrlParams.ts
@@ -1,0 +1,46 @@
+import { useSearchParams } from 'react-router-dom'
+import { useEffect } from 'react'
+
+interface UrlParamConfig<T extends string> {
+    param: string
+    value: T | undefined
+    defaultValue: T
+}
+
+export function useUrlParams<T extends string>(params: UrlParamConfig<T>[]) {
+    const [searchParams, setSearchParams] = useSearchParams()
+
+    useEffect(() => {
+        // Check if current params are different from desired params
+        let needsUpdate = false
+        const currentParams = new URLSearchParams(searchParams)
+
+        params.forEach(({ param, value, defaultValue }) => {
+            const currentValue = currentParams.get(param)
+            const targetValue = value !== defaultValue ? value || defaultValue : null
+
+            if (targetValue === null && currentValue !== null) {
+                needsUpdate = true
+            } else if (targetValue !== null && targetValue !== currentValue) {
+                needsUpdate = true
+            }
+        })
+
+        // Only update if necessary
+        if (needsUpdate) {
+            setSearchParams((prevParams) => {
+                const newParams = new URLSearchParams(prevParams)
+
+                params.forEach(({ param, value, defaultValue }) => {
+                    if (value !== defaultValue) {
+                        newParams.set(param, value || defaultValue)
+                    } else {
+                        newParams.delete(param)
+                    }
+                })
+
+                return newParams
+            })
+        }
+    }, [params, searchParams, setSearchParams])
+}

--- a/src/pages/OperatorsPage.tsx
+++ b/src/pages/OperatorsPage.tsx
@@ -45,8 +45,6 @@ function isTabOption(value: unknown): value is TabOption {
 }
 
 export const OperatorsPage = () => {
-    const [searchQuery, setSearchQuery] = useState('')
-
     const wallet = useWalletAccount()
     const isWalletLoading = useIsWalletLoading()
 
@@ -58,6 +56,7 @@ export const OperatorsPage = () => {
     const [params] = useSearchParams()
     const tab = params.get('tab')
     const selectedTab = isTabOption(tab) ? tab : DEFAULT_TAB
+    const [searchQuery, setSearchQuery] = useState(params.get('search') || '')
 
     useUrlParams([
         {
@@ -74,6 +73,11 @@ export const OperatorsPage = () => {
             param: 'orderDir',
             value: orderDirection,
             defaultValue: DEFAULT_ORDER_DIRECTION,
+        },
+        {
+            param: 'search',
+            value: searchQuery,
+            defaultValue: '',
         },
     ])
 
@@ -120,6 +124,7 @@ export const OperatorsPage = () => {
             <NetworkHelmet title="Operators" />
             <NetworkActionBar
                 searchEnabled={true}
+                searchValue={searchQuery}
                 onSearch={setSearchQuery}
                 leftSideContent={
                     <Tabs

--- a/src/pages/SponsorshipsPage.tsx
+++ b/src/pages/SponsorshipsPage.tsx
@@ -44,9 +44,18 @@ function isTabOption(value: unknown): value is TabOption {
 }
 
 export const SponsorshipsPage = () => {
-    const [searchQuery, setSearchQuery] = useState('')
+    const [params] = useSearchParams()
+    const initialFilters = {
+        ...defaultFilters,
+        ...Object.keys(defaultFilters).reduce((acc, key) => {
+            if (params.has(key)) {
+                return { ...acc, [key]: params.get(key) === 'true' }
+            }
+            return acc
+        }, {}),
+    }
 
-    const [filters, setFilters] = useState<SponsorshipFilters>(defaultFilters)
+    const [filters, setFilters] = useState<SponsorshipFilters>(initialFilters)
 
     const wallet = useWalletAccount()
     const isWalletLoading = useIsWalletLoading()
@@ -56,9 +65,10 @@ export const SponsorshipsPage = () => {
         orderDirection: DEFAULT_ORDER_DIRECTION,
     })
 
-    const [params] = useSearchParams()
     const tab = params.get('tab')
     const selectedTab = isTabOption(tab) ? tab : DEFAULT_TAB
+
+    const [searchQuery, setSearchQuery] = useState(params.get('search') || '')
 
     useUrlParams([
         {
@@ -76,6 +86,16 @@ export const SponsorshipsPage = () => {
             value: orderDirection,
             defaultValue: DEFAULT_ORDER_DIRECTION,
         },
+        {
+            param: 'search',
+            value: searchQuery,
+            defaultValue: '',
+        },
+        ...Object.entries(defaultFilters).map(([key, value]) => ({
+            param: key,
+            value: filters[key as keyof SponsorshipFilters].toString(),
+            defaultValue: value.toString(),
+        })),
     ])
 
     const allSponsorshipsQuery = useAllSponsorshipsQuery({
@@ -123,6 +143,7 @@ export const SponsorshipsPage = () => {
             <NetworkHelmet title="Sponsorships" />
             <NetworkActionBar
                 searchEnabled
+                searchValue={searchQuery}
                 onSearch={setSearchQuery}
                 leftSideContent={
                     <Tabs

--- a/src/shared/stores/wallet.ts
+++ b/src/shared/stores/wallet.ts
@@ -161,6 +161,7 @@ export async function getWalletAccount({
 interface WalletStore {
     account: string | undefined
     ens: Record<string, string | undefined>
+    isLoading: boolean
 }
 
 const useWalletStore = create<WalletStore>((set, get) => {
@@ -219,6 +220,12 @@ const useWalletStore = create<WalletStore>((set, get) => {
             onAccountsChange(accounts)
         } catch (e) {
             console.warn('Provider setup failed', e)
+        } finally {
+            set((current) =>
+                produce(current, (next) => {
+                    next.isLoading = false
+                }),
+            )
         }
     })
 
@@ -226,6 +233,7 @@ const useWalletStore = create<WalletStore>((set, get) => {
         account: undefined,
 
         ens: {},
+        isLoading: true,
     }
 })
 
@@ -236,6 +244,14 @@ const useWalletStore = create<WalletStore>((set, get) => {
  */
 export function useWalletAccount() {
     return useWalletStore().account
+}
+
+/**
+ * A hook that gives you the loading state of the wallet.
+ * @returns a boolean value indicating whether the wallet is loading.
+ */
+export function useIsWalletLoading() {
+    return useWalletStore().isLoading
 }
 
 /**


### PR DESCRIPTION
We now keep search parameter and selected tab in the URL for both operator listing and sponsorship listing pages. For sponsorships we also keep current filters in the URL parameters.