### PR TITLE
FRONT-1978: Update `@streamr/config` to the "typed" version (v5.5.0) + clean up

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@metamask/providers": "^17.1.2",
         "@sambego/storybook-styles": "^1.0.0",
         "@sentry/react": "^8.34.0",
-        "@streamr/config": "^5.4.0",
+        "@streamr/config": "^5.5.0",
         "@streamr/hub-contracts": "^1.1.2",
         "@streamr/sdk": "^102.0.0",
         "@streamr/streamr-icons": "^0.1.9",
@@ -10842,9 +10842,10 @@
       }
     },
     "node_modules/@streamr/config": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/@streamr/config/-/config-5.4.2.tgz",
-      "integrity": "sha512-x+VW0s9ydY1oT16D8FP3GE/dGPpAfjvQ6ncZvxs0McuT63T1XtMAHaIDcVcw8eOhbjYToSfHEzLwZ23biEFsBg=="
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@streamr/config/-/config-5.5.0.tgz",
+      "integrity": "sha512-c/opTpszvtgM1F/TZDo0KwiqsI29bIYcleV+hn86vonYrEXKSr3m97nwq9oHoThyfW1foO2PkadZRuqBZyjxNA==",
+      "license": "STREAMR NETWORK OPEN SOURCE LICENSE"
     },
     "node_modules/@streamr/dht": {
       "version": "102.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@metamask/providers": "^17.1.2",
     "@sambego/storybook-styles": "^1.0.0",
     "@sentry/react": "^8.34.0",
-    "@streamr/config": "^5.4.0",
+    "@streamr/config": "^5.5.0",
     "@streamr/hub-contracts": "^1.1.2",
     "@streamr/sdk": "^102.0.0",
     "@streamr/streamr-icons": "^0.1.9",

--- a/src/components/ChainSelector.tsx
+++ b/src/components/ChainSelector.tsx
@@ -1,3 +1,4 @@
+import { Chain } from '@streamr/config'
 import React from 'react'
 import { useSearchParams } from 'react-router-dom'
 import styled from 'styled-components'
@@ -5,10 +6,9 @@ import { SimpleDropdown, SimpleListDropdownMenu } from '~/components/SimpleDropd
 import { getEnvironmentConfig } from '~/getters/getEnvironmentConfig'
 import UnstyledNetworkIcon from '~/shared/components/NetworkIcon'
 import SvgIcon from '~/shared/components/SvgIcon'
-import { getSymbolicChainName, useCurrentChain } from '~/utils/chains'
 import { COLORS, LAPTOP } from '~/shared/utils/styled'
 import { StreamDraft } from '~/stores/streamDraft'
-import { Chain } from '~/types'
+import { getSymbolicChainName, useCurrentChain } from '~/utils/chains'
 
 type MenuItemProps = {
     chain: Chain

--- a/src/components/ChainSelector.tsx
+++ b/src/components/ChainSelector.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { useSearchParams } from 'react-router-dom'
 import styled from 'styled-components'
 import { SimpleDropdown, SimpleListDropdownMenu } from '~/components/SimpleDropdown'
+import { defaultChainKey } from '~/consts'
 import { getEnvironmentConfig } from '~/getters/getEnvironmentConfig'
 import UnstyledNetworkIcon from '~/shared/components/NetworkIcon'
 import SvgIcon from '~/shared/components/SvgIcon'
@@ -49,7 +50,7 @@ const Menu = ({ chains, selectedChain, toggle }: MenuProps) => {
                             setSearchParams((prev) => {
                                 const { chain: _, ...rest } = Object.fromEntries(prev)
 
-                                return chainName === 'polygon'
+                                return chainName === defaultChainKey
                                     ? rest
                                     : { ...rest, chain: chainName }
                             })

--- a/src/consts.tsx
+++ b/src/consts.tsx
@@ -1,3 +1,5 @@
+import { ChainKey } from '@streamr/config'
+
 export const MaxSearchPhraseLength = 250
 
 export const address0 = '0x0000000000000000000000000000000000000000'
@@ -10,3 +12,5 @@ export const StreamGptApiUrl = process.env.STREAM_GPT_API_URL
 export const Minute = 60000
 
 export const DayInSeconds = 86400
+
+export const defaultChainKey: ChainKey = 'polygon'

--- a/src/getters/getClientConfig.ts
+++ b/src/getters/getClientConfig.ts
@@ -17,7 +17,7 @@ export default function getClientConfig(
     if (chainConfig.entryPoints && chainConfig.entryPoints.length > 0) {
         config.network = {
             controlLayer: {
-                entryPoints: chainConfig.entryPoints,
+                entryPoints: [...chainConfig.entryPoints],
             },
         }
     }

--- a/src/getters/getEnvironmentConfig.ts
+++ b/src/getters/getEnvironmentConfig.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import config from '~/config/environments.toml'
+import { defaultChainKey } from '~/consts'
 import { getChainConfig } from '~/utils/chains'
 
 const EnvironmentConfig = z
@@ -37,7 +38,7 @@ const EnvironmentConfig = z
 type EnvironmentConfig = z.infer<typeof EnvironmentConfig>
 
 const fallbackEnvironmentConfig: EnvironmentConfig = EnvironmentConfig.parse({
-    availableChains: ['polygon'],
+    availableChains: [defaultChainKey],
 })
 
 const parsedConfig = z

--- a/src/pages/ProjectPage/ProjectEditorPage.tsx
+++ b/src/pages/ProjectPage/ProjectEditorPage.tsx
@@ -1,3 +1,4 @@
+import { Chain } from '@streamr/config'
 import React, { useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import styled, { css } from 'styled-components'
@@ -21,18 +22,17 @@ import { deleteProject } from '~/services/projects'
 import { DetailsPageHeader } from '~/shared/components/DetailsPageHeader'
 import LoadingIndicator from '~/shared/components/LoadingIndicator'
 import useIsMounted from '~/shared/hooks/useIsMounted'
+import { ProjectType, SalePoint } from '~/shared/types'
+import { ProjectDraft } from '~/stores/projectDraft'
+import { SalePointsPayload } from '~/types/projects'
+import { formatChainName } from '~/utils'
 import {
     getChainConfig,
     getChainConfigExtension,
     useCurrentChainId,
 } from '~/utils/chains'
-import { ProjectType, SalePoint } from '~/shared/types'
-import { ProjectDraft } from '~/stores/projectDraft'
-import { Chain } from '~/types'
-import { SalePointsPayload } from '~/types/projects'
-import { formatChainName } from '~/utils'
-import { toastedOperation } from '~/utils/toastedOperation'
 import { Route as R, routeOptions } from '~/utils/routes'
+import { toastedOperation } from '~/utils/toastedOperation'
 import DataUnionFee from './DataUnionFee'
 import DataUnionPayment from './DataUnionPayment'
 import EditorHero from './EditorHero'

--- a/src/parsers/ProjectParser.ts
+++ b/src/parsers/ProjectParser.ts
@@ -1,3 +1,4 @@
+import { Chain } from '@streamr/config'
 import { z } from 'zod'
 import { address0 } from '~/consts'
 import { getProjectImageUrl } from '~/getters'
@@ -9,7 +10,6 @@ import {
     timeUnitSecondsMultiplierMap,
     timeUnits,
 } from '~/shared/utils/timeUnit'
-import { Chain } from '~/types'
 import { toBigInt } from '~/utils/bn'
 import {
     getChainConfig,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,3 @@
-import { config as configs } from '@streamr/config'
 import { MessageID } from '@streamr/sdk'
 import { TheGraph } from '~/shared/types'
 
@@ -41,32 +40,6 @@ export type ChainConfigKey =
     | 'minimumDelegationSeconds'
     | 'minimumDelegationWei'
     | 'earlyLeaverPenaltyWei'
-
-type ContractAddressKey = typeof configs extends Record<
-    any,
-    Record<'contracts', Partial<Record<infer K, string>>>
->
-    ? K
-    : never
-
-export interface Chain {
-    name: string
-    id: number
-    theGraphUrl?: string
-    rpcEndpoints: { url: string }[]
-    contracts: Partial<Record<ContractAddressKey | (string & {}), string>>
-    entryPoints?: {
-        nodeId: string
-        websocket: {
-            host: string
-            port: number
-            tls: boolean
-        }
-    }[]
-    nativeCurrency: { symbol: string; name: string; decimals: number }
-    blockExplorerUrl?: string
-    adminPrivateKey?: string
-}
 
 export type OrderDirection = 'asc' | 'desc'
 

--- a/src/utils/chains.ts
+++ b/src/utils/chains.ts
@@ -1,4 +1,4 @@
-import { Chain, Config, config as configs } from '@streamr/config'
+import { Chain, config as configs } from '@streamr/config'
 import { produce } from 'immer'
 import { useMemo } from 'react'
 import { useSearchParams } from 'react-router-dom'

--- a/src/utils/chains.ts
+++ b/src/utils/chains.ts
@@ -3,6 +3,7 @@ import { produce } from 'immer'
 import { useMemo } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { ethereumNetworks } from '~/shared/utils/constants'
+import { defaultChainKey } from '~/consts'
 import {
     ChainConfigExtension,
     fallbackChainConfigExtension,
@@ -23,12 +24,12 @@ function getChainConfigWithFallback(chainName: string): Chain {
         return getChainConfig(chainName)
     } catch (_) {}
 
-    return getChainConfig('polygon')
+    return getChainConfig(defaultChainKey)
 }
 
 export function getCurrentChain() {
     return getChainConfigWithFallback(
-        new URLSearchParams(window.location.search).get('chain') || 'polygon',
+        new URLSearchParams(window.location.search).get('chain') || defaultChainKey,
     )
 }
 
@@ -37,7 +38,7 @@ export function getCurrentChainId() {
 }
 
 export function useCurrentChain() {
-    const chainName = useSearchParams()[0].get('chain') || 'polygon'
+    const chainName = useSearchParams()[0].get('chain') || defaultChainKey
 
     return useMemo(() => getChainConfigWithFallback(chainName), [chainName])
 }

--- a/src/utils/chains.ts
+++ b/src/utils/chains.ts
@@ -1,14 +1,13 @@
-import { config as configs } from '@streamr/config'
+import { Chain, Config, config as configs } from '@streamr/config'
 import { produce } from 'immer'
 import { useMemo } from 'react'
 import { useSearchParams } from 'react-router-dom'
+import { ethereumNetworks } from '~/shared/utils/constants'
 import {
     ChainConfigExtension,
     fallbackChainConfigExtension,
     parsedChainConfigExtension,
 } from '~/utils/chainConfigExtension'
-import { Chain } from '~/types'
-import { ethereumNetworks } from '~/shared/utils/constants'
 import formatConfigUrl from './formatConfigUrl'
 
 function getPreferredChainName(chainName: string) {

--- a/src/utils/contracts.ts
+++ b/src/utils/contracts.ts
@@ -97,8 +97,6 @@ export function getContractAddress(
                 return contracts.SponsorshipStakeWeightedAllocationPolicy
             case 'sponsorshipVoteKickPolicy':
                 return contracts.SponsorshipVoteKickPolicy
-            case 'sponsorshipPaymentToken':
-                return contracts.SponsorshipPaymentToken
             case 'streamRegistry':
                 return contracts.StreamRegistry
             case 'streamStorage':

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -1,4 +1,5 @@
 import queryString from 'query-string'
+import { defaultChainKey } from '~/consts'
 import { getSymbolicChainName } from './chains'
 
 interface RouteOptions {
@@ -27,7 +28,7 @@ function withSuffix<P extends string>(pathname: P, options: RouteOptions = {}) {
 
     const qs = options.search
         ? queryString.stringify(
-              chain === 'polygon'
+              chain === defaultChainKey
                   ? search
                   : {
                         ...search,


### PR DESCRIPTION
In this PR I make sure we're using the latest `@streamr/config` package (exposes proper types for the config and chains). I also clean things up a bit. There's room for more but I don't wanna pollute it just yet (#1965 could be addressed first).

#### Future improvement material

- The new config package exposes `ChainKey` (`polygon`, `dev0`, …) which could be use to narrow hub's types even further.