### PR TITLE
Replace "chain symbolic name" with "chain key"

### DIFF
--- a/src/components/ActionBar.tsx
+++ b/src/components/ActionBar.tsx
@@ -73,7 +73,7 @@ const UnstyledActionBar = ({
 
     const navigate = useNavigate()
 
-    const chainName = useCurrentChainKey()
+    const chainKey = useCurrentChainKey()
 
     return (
         <ActionBarContainer {...props}>
@@ -93,7 +93,7 @@ const UnstyledActionBar = ({
                     <Tabs
                         selection={scope}
                         onSelectionChange={(id) => {
-                            navigate(R.projects(routeOptions(chainName, { tab: id })))
+                            navigate(R.projects(routeOptions(chainKey, { tab: id })))
                         }}
                     >
                         <Tab id={TabOption.Any}>All projects</Tab>

--- a/src/components/ActionBar.tsx
+++ b/src/components/ActionBar.tsx
@@ -20,7 +20,7 @@ import Tabs, { Tab } from '~/shared/components/Tabs'
 import { useWalletAccount } from '~/shared/stores/wallet'
 import { TheGraph } from '~/shared/types'
 import { ProjectFilter } from '~/types'
-import { useCurrentChainSymbolicName } from '~/utils/chains'
+import { useCurrentChainKey } from '~/utils/chains'
 import { Route as R, routeOptions } from '~/utils/routes'
 
 export enum TabOption {
@@ -73,7 +73,7 @@ const UnstyledActionBar = ({
 
     const navigate = useNavigate()
 
-    const chainName = useCurrentChainSymbolicName()
+    const chainName = useCurrentChainKey()
 
     return (
         <ActionBarContainer {...props}>

--- a/src/components/ActionBars/AboutSponsorship.tsx
+++ b/src/components/ActionBars/AboutSponsorship.tsx
@@ -24,7 +24,7 @@ interface AboutSponsorshipProps {
 export function AboutSponsorship({ sponsorship }: AboutSponsorshipProps) {
     const { streamId } = sponsorship
 
-    const chainName = useCurrentChainKey()
+    const chainKey = useCurrentChainKey()
 
     return (
         <DefaultSimpleDropdownMenu>
@@ -35,7 +35,7 @@ export function AboutSponsorship({ sponsorship }: AboutSponsorshipProps) {
                         <strong>{truncateStreamName(streamId)}</strong>
                         <div>
                             <Link
-                                to={R.stream(streamId, routeOptions(chainName))}
+                                to={R.stream(streamId, routeOptions(chainKey))}
                                 target="_blank"
                             >
                                 <ExternalLinkIcon />

--- a/src/components/ActionBars/AboutSponsorship.tsx
+++ b/src/components/ActionBars/AboutSponsorship.tsx
@@ -14,7 +14,7 @@ import { SponsorshipPaymentTokenName } from '~/components/SponsorshipPaymentToke
 import { ExternalLinkIcon } from '~/icons'
 import { Sponsorship } from '~/parsers/Sponsorship'
 import { truncateStreamName } from '~/shared/utils/text'
-import { useCurrentChainSymbolicName } from '~/utils/chains'
+import { useCurrentChainKey } from '~/utils/chains'
 import { Route as R, routeOptions } from '~/utils/routes'
 
 interface AboutSponsorshipProps {
@@ -24,7 +24,7 @@ interface AboutSponsorshipProps {
 export function AboutSponsorship({ sponsorship }: AboutSponsorshipProps) {
     const { streamId } = sponsorship
 
-    const chainName = useCurrentChainSymbolicName()
+    const chainName = useCurrentChainKey()
 
     return (
         <DefaultSimpleDropdownMenu>

--- a/src/components/ActionBars/SponsorshipActionBar.tsx
+++ b/src/components/ActionBars/SponsorshipActionBar.tsx
@@ -73,11 +73,11 @@ export function SponsorshipActionBar({ sponsorship }: SponsorshipActionBarProps)
 
     const chainId = useCurrentChainId()
 
-    const chainName = useCurrentChainKey()
+    const chainKey = useCurrentChainKey()
 
     return (
         <AbstractActionBar
-            fallbackBackButtonUrl={R.sponsorships(routeOptions(chainName))}
+            fallbackBackButtonUrl={R.sponsorships(routeOptions(chainKey))}
             title={
                 streamId ? (
                     truncateStreamName(streamId, 30)

--- a/src/components/ActionBars/SponsorshipActionBar.tsx
+++ b/src/components/ActionBars/SponsorshipActionBar.tsx
@@ -26,7 +26,7 @@ import SvgIcon from '~/shared/components/SvgIcon'
 import { useWalletAccount } from '~/shared/stores/wallet'
 import { COLORS } from '~/shared/utils/styled'
 import { truncate, truncateStreamName } from '~/shared/utils/text'
-import { useCurrentChainId, useCurrentChainSymbolicName } from '~/utils/chains'
+import { useCurrentChainId, useCurrentChainKey } from '~/utils/chains'
 import { Route as R, routeOptions } from '~/utils/routes'
 import { isSponsorshipFundedByOperator } from '~/utils/sponsorships'
 import { AbstractActionBar } from './AbstractActionBar'
@@ -73,7 +73,7 @@ export function SponsorshipActionBar({ sponsorship }: SponsorshipActionBarProps)
 
     const chainId = useCurrentChainId()
 
-    const chainName = useCurrentChainSymbolicName()
+    const chainName = useCurrentChainKey()
 
     return (
         <AbstractActionBar

--- a/src/components/ChainSelector.tsx
+++ b/src/components/ChainSelector.tsx
@@ -9,7 +9,7 @@ import UnstyledNetworkIcon from '~/shared/components/NetworkIcon'
 import SvgIcon from '~/shared/components/SvgIcon'
 import { COLORS, LAPTOP } from '~/shared/utils/styled'
 import { StreamDraft } from '~/stores/streamDraft'
-import { getSymbolicChainName, useCurrentChain } from '~/utils/chains'
+import { getChainKey, useCurrentChain } from '~/utils/chains'
 
 type MenuItemProps = {
     chain: Chain
@@ -45,7 +45,7 @@ const Menu = ({ chains, selectedChain, toggle }: MenuProps) => {
                         onClick={() => {
                             toggle(false)
 
-                            const chainName = getSymbolicChainName(c.id)
+                            const chainName = getChainKey(c.id)
 
                             setSearchParams((prev) => {
                                 const { chain: _, ...rest } = Object.fromEntries(prev)

--- a/src/components/ChainSelector.tsx
+++ b/src/components/ChainSelector.tsx
@@ -45,14 +45,14 @@ const Menu = ({ chains, selectedChain, toggle }: MenuProps) => {
                         onClick={() => {
                             toggle(false)
 
-                            const chainName = getChainKey(c.id)
+                            const chainKey = getChainKey(c.id)
 
                             setSearchParams((prev) => {
                                 const { chain: _, ...rest } = Object.fromEntries(prev)
 
-                                return chainName === defaultChainKey
+                                return chainKey === defaultChainKey
                                     ? rest
-                                    : { ...rest, chain: chainName }
+                                    : { ...rest, chain: chainKey }
                             })
                         }}
                     />

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,15 +1,15 @@
+import {
+    FooterColumn,
+    SocialChannels,
+    FooterColumns as UnstyledFooterColumns,
+    Footer as UnstyledLayoutFooter,
+    MadeBy as UnstyledMadeBy,
+} from '@streamr/streamr-layout'
 import React from 'react'
 import styled from 'styled-components'
-import {
-    Footer as UnstyledLayoutFooter,
-    FooterColumn,
-    FooterColumns as UnstyledFooterColumns,
-    MadeBy as UnstyledMadeBy,
-    SocialChannels,
-} from '@streamr/streamr-layout'
 import { COLORS } from '~/shared/utils/styled'
+import { useCurrentChainKey } from '~/utils/chains'
 import { Route as R, routeOptions } from '~/utils/routes'
-import { useCurrentChainSymbolicName } from '~/utils/chains'
 
 const MadeBy = styled(UnstyledMadeBy)`
     padding: 0 0 32px;
@@ -30,7 +30,7 @@ const FooterColumns = styled(UnstyledFooterColumns)`
 `
 
 const Footer = ({ topBorder = false }) => {
-    const chainName = useCurrentChainSymbolicName()
+    const chainName = useCurrentChainKey()
 
     return (
         <LayoutFooter>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -30,7 +30,7 @@ const FooterColumns = styled(UnstyledFooterColumns)`
 `
 
 const Footer = ({ topBorder = false }) => {
-    const chainName = useCurrentChainKey()
+    const chainKey = useCurrentChainKey()
 
     return (
         <LayoutFooter>
@@ -56,7 +56,7 @@ const Footer = ({ topBorder = false }) => {
                 </FooterColumn>
                 <FooterColumn title="Apps">
                     <a href={R.networkExplorer()}>Network Explorer</a>
-                    <a href={R.hub(routeOptions(chainName))}>Hub</a>
+                    <a href={R.hub(routeOptions(chainKey))}>Hub</a>
                 </FooterColumn>
                 <FooterColumn title="Contact">
                     <a href={R.contactGeneral()}>General</a>

--- a/src/components/Nav/NetworkAccordion.tsx
+++ b/src/components/Nav/NetworkAccordion.tsx
@@ -3,8 +3,8 @@ import { Link, useLocation } from 'react-router-dom'
 import styled, { css } from 'styled-components'
 import SvgIcon from '~/shared/components/SvgIcon'
 import { COLORS, MEDIUM, REGULAR } from '~/shared/utils/styled'
+import { useCurrentChainKey } from '~/utils/chains'
 import { Route as R, routeOptions } from '~/utils/routes'
-import { useCurrentChainSymbolicName } from '~/utils/chains'
 import { NavLink, NavbarLinkMobile } from './Nav.styles'
 import { NetworkNavItems, isNetworkTabActive } from './NetworkDropdown'
 
@@ -13,7 +13,7 @@ export function NetworkAccordion() {
 
     const [isOpen, toggle] = useReducer((x) => !x, false)
 
-    const chainName = useCurrentChainSymbolicName()
+    const chainName = useCurrentChainKey()
 
     return (
         <>

--- a/src/components/Nav/NetworkAccordion.tsx
+++ b/src/components/Nav/NetworkAccordion.tsx
@@ -13,7 +13,7 @@ export function NetworkAccordion() {
 
     const [isOpen, toggle] = useReducer((x) => !x, false)
 
-    const chainName = useCurrentChainKey()
+    const chainKey = useCurrentChainKey()
 
     return (
         <>
@@ -23,7 +23,7 @@ export function NetworkAccordion() {
             >
                 <NavLink
                     as={Link}
-                    to={R.networkOverview(routeOptions(chainName))}
+                    to={R.networkOverview(routeOptions(chainKey))}
                     onClick={(e) => {
                         e.preventDefault()
 
@@ -47,7 +47,7 @@ export function NetworkAccordion() {
                         return (
                             <NetworkMobileLink
                                 {...rest}
-                                to={linkFn(routeOptions(chainName))}
+                                to={linkFn(routeOptions(chainKey))}
                                 key={title}
                             >
                                 <NetworkNavElement>

--- a/src/components/Nav/NetworkDropdown.tsx
+++ b/src/components/Nav/NetworkDropdown.tsx
@@ -39,7 +39,7 @@ export function Dropdown() {
         }, 250)
     }
 
-    const chainName = useCurrentChainKey()
+    const chainKey = useCurrentChainKey()
 
     return (
         <NavbarLinkDesktop highlight={isOpen || isNetworkTabActive(pathname)}>
@@ -54,7 +54,7 @@ export function Dropdown() {
                             <DropdownItem
                                 $active={pathname.startsWith(i.linkFn())}
                                 key={i.title}
-                                to={i.linkFn(routeOptions(chainName))}
+                                to={i.linkFn(routeOptions(chainKey))}
                                 onFocus={() => void show(toggle)}
                                 onClick={() => void hide(toggle, { immediately: true })}
                             >
@@ -68,7 +68,7 @@ export function Dropdown() {
                 {(toggle) => (
                     <NavLink
                         as={Link}
-                        to={R.networkOverview(routeOptions(chainName))}
+                        to={R.networkOverview(routeOptions(chainKey))}
                         onFocus={() => void show(toggle)}
                         onBlur={() => void hide(toggle)}
                         onMouseEnter={() => void show(toggle)}

--- a/src/components/Nav/NetworkDropdown.tsx
+++ b/src/components/Nav/NetworkDropdown.tsx
@@ -5,7 +5,7 @@ import { NavLink, NavbarLinkDesktop } from '~/components/Nav/Nav.styles'
 import { DefaultSimpleDropdownMenu, SimpleDropdown } from '~/components/SimpleDropdown'
 import SvgIcon from '~/shared/components/SvgIcon'
 import { COLORS } from '~/shared/utils/styled'
-import { useCurrentChainSymbolicName } from '~/utils/chains'
+import { useCurrentChainKey } from '~/utils/chains'
 import { Route as R, routeOptions } from '~/utils/routes'
 
 export function Dropdown() {
@@ -39,7 +39,7 @@ export function Dropdown() {
         }, 250)
     }
 
-    const chainName = useCurrentChainSymbolicName()
+    const chainName = useCurrentChainKey()
 
     return (
         <NavbarLinkDesktop highlight={isOpen || isNetworkTabActive(pathname)}>

--- a/src/components/Nav/index.tsx
+++ b/src/components/Nav/index.tsx
@@ -55,7 +55,7 @@ const UnstyledDesktopNav: FunctionComponent = (props) => {
 
     const chainId = useCurrentChainId()
 
-    const chainName = useCurrentChainKey()
+    const chainKey = useCurrentChainKey()
 
     return (
         <div {...props} data-testid={'desktop-nav'}>
@@ -70,14 +70,14 @@ const UnstyledDesktopNav: FunctionComponent = (props) => {
                     <div />
                     <NavbarItem>
                         <NavbarLinkDesktop highlight={pathname.startsWith(R.projects())}>
-                            <NavLink as={Link} to={R.projects(routeOptions(chainName))}>
+                            <NavLink as={Link} to={R.projects(routeOptions(chainKey))}>
                                 Projects
                             </NavLink>
                         </NavbarLinkDesktop>
                     </NavbarItem>
                     <NavbarItem>
                         <NavbarLinkDesktop highlight={pathname.startsWith(R.streams())}>
-                            <NavLink as={Link} to={R.streams(routeOptions(chainName))}>
+                            <NavLink as={Link} to={R.streams(routeOptions(chainKey))}>
                                 Streams
                             </NavLink>
                         </NavbarLinkDesktop>
@@ -137,7 +137,7 @@ const UnstyledDesktopNav: FunctionComponent = (props) => {
                                                         navigate(
                                                             R.operator(
                                                                 operator.id,
-                                                                routeOptions(chainName),
+                                                                routeOptions(chainKey),
                                                             ),
                                                         )
                                                     }}
@@ -201,7 +201,7 @@ const UnstyledMobileNav: FunctionComponent<{ className?: string }> = ({ classNam
 
     const { pathname } = useLocation()
 
-    const chainName = useCurrentChainKey()
+    const chainKey = useCurrentChainKey()
 
     return (
         <NavOverlay className={className}>
@@ -225,12 +225,12 @@ const UnstyledMobileNav: FunctionComponent<{ className?: string }> = ({ classNam
                     </UserInfoMobile>
                 )}
                 <NavbarLinkMobile highlight={pathname.startsWith(R.projects())}>
-                    <NavLink as={Link} to={R.projects(routeOptions(chainName))}>
+                    <NavLink as={Link} to={R.projects(routeOptions(chainKey))}>
                         Projects
                     </NavLink>
                 </NavbarLinkMobile>
                 <NavbarLinkMobile highlight={pathname.startsWith(R.streams())}>
-                    <NavLink as={Link} to={R.streams(routeOptions(chainName))}>
+                    <NavLink as={Link} to={R.streams(routeOptions(chainKey))}>
                         Streams
                     </NavLink>
                 </NavbarLinkMobile>

--- a/src/components/Nav/index.tsx
+++ b/src/components/Nav/index.tsx
@@ -1,21 +1,19 @@
-import React, { FunctionComponent, HTMLAttributes } from 'react'
-import styled from 'styled-components'
-import { useLocation, Link, useNavigate } from 'react-router-dom'
 import { Button, HamburgerButton, Logo, NavOverlay } from '@streamr/streamr-layout'
-import { DESKTOP, TABLET } from '~/shared/utils/styled'
-import SvgIcon from '~/shared/components/SvgIcon'
-import { truncate } from '~/shared/utils/text'
-import { connectModal } from '~/modals/ConnectModal'
-import { useEns, useWalletAccount } from '~/shared/stores/wallet'
-import toast from '~/utils/toast'
-import { useOperatorForWalletQuery } from '~/hooks/operators'
-import { saveOperator } from '~/utils'
-import { useMediaQuery } from '~/hooks'
+import React, { FunctionComponent, HTMLAttributes } from 'react'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
+import styled from 'styled-components'
 import { ChainSelector as UnstyledChainSelector } from '~/components/ChainSelector'
-import { useCurrentChainId } from '~/utils/chains'
+import { useMediaQuery } from '~/hooks'
+import { useOperatorForWalletQuery } from '~/hooks/operators'
+import { connectModal } from '~/modals/ConnectModal'
+import SvgIcon from '~/shared/components/SvgIcon'
+import { useEns, useWalletAccount } from '~/shared/stores/wallet'
+import { DESKTOP, TABLET } from '~/shared/utils/styled'
+import { truncate } from '~/shared/utils/text'
+import { saveOperator } from '~/utils'
+import { useCurrentChainId, useCurrentChainKey } from '~/utils/chains'
 import { Route as R, routeOptions } from '~/utils/routes'
-import { useCurrentChainSymbolicName } from '~/utils/chains'
-import { Avatarless, Name, Username } from './User'
+import toast from '~/utils/toast'
 import {
     Avatar,
     LogoLink,
@@ -36,8 +34,9 @@ import {
     UserInfoMobile,
     WalletAddress,
 } from './Nav.styles'
-import { Dropdown } from './NetworkDropdown'
 import { NetworkAccordion } from './NetworkAccordion'
+import { Dropdown } from './NetworkDropdown'
+import { Avatarless, Name, Username } from './User'
 
 const UnstyledDesktopNav: FunctionComponent = (props) => {
     const { pathname } = useLocation()
@@ -56,7 +55,7 @@ const UnstyledDesktopNav: FunctionComponent = (props) => {
 
     const chainId = useCurrentChainId()
 
-    const chainName = useCurrentChainSymbolicName()
+    const chainName = useCurrentChainKey()
 
     return (
         <div {...props} data-testid={'desktop-nav'}>
@@ -202,7 +201,7 @@ const UnstyledMobileNav: FunctionComponent<{ className?: string }> = ({ classNam
 
     const { pathname } = useLocation()
 
-    const chainName = useCurrentChainSymbolicName()
+    const chainName = useCurrentChainKey()
 
     return (
         <NavOverlay className={className}>

--- a/src/components/QueriedSponsorshipsTable.tsx
+++ b/src/components/QueriedSponsorshipsTable.tsx
@@ -53,7 +53,7 @@ export function QueriedSponsorshipsTable({
 
     const chainId = useCurrentChainId()
 
-    const chainName = useCurrentChainKey()
+    const chainKey = useCurrentChainKey()
 
     const fundSponsorship = useFundSponsorshipCallback()
 
@@ -223,7 +223,7 @@ export function QueriedSponsorshipsTable({
                 noDataFirstLine={noDataFirstLine}
                 noDataSecondLine={noDataSecondLine}
                 linkMapper={(element) =>
-                    R.sponsorship(element.id, routeOptions(chainName))
+                    R.sponsorship(element.id, routeOptions(chainKey))
                 }
             />
             {query.hasNextPage && (

--- a/src/components/QueriedSponsorshipsTable.tsx
+++ b/src/components/QueriedSponsorshipsTable.tsx
@@ -20,7 +20,7 @@ import { Sponsorship } from '~/parsers/Sponsorship'
 import { ScrollTableCore } from '~/shared/components/ScrollTable/ScrollTable'
 import { useWalletAccount } from '~/shared/stores/wallet'
 import { OrderDirection } from '~/types'
-import { useCurrentChainId, useCurrentChainSymbolicName } from '~/utils/chains'
+import { useCurrentChainId, useCurrentChainKey } from '~/utils/chains'
 import { Route as R, routeOptions } from '~/utils/routes'
 import { isSponsorshipFundedByOperator } from '~/utils/sponsorships'
 
@@ -53,7 +53,7 @@ export function QueriedSponsorshipsTable({
 
     const chainId = useCurrentChainId()
 
-    const chainName = useCurrentChainSymbolicName()
+    const chainName = useCurrentChainKey()
 
     const fundSponsorship = useFundSponsorshipCallback()
 

--- a/src/components/QueriedStreamsTable.tsx
+++ b/src/components/QueriedStreamsTable.tsx
@@ -42,7 +42,7 @@ export function QueriedStreamsTable({
 
     const chainId = useCurrentChainId()
 
-    const chainName = useCurrentChainKey()
+    const chainKey = useCurrentChainKey()
 
     const indexerQueryErrored = query.isError && isIndexerColumn(chainId, orderBy)
 
@@ -141,7 +141,7 @@ export function QueriedStreamsTable({
                         valueMapper: ({ subscriberCount = '∞' }) => subscriberCount,
                     },
                 ]}
-                linkMapper={(element) => R.stream(element.id, routeOptions(chainName))}
+                linkMapper={(element) => R.stream(element.id, routeOptions(chainKey))}
             />
             {query.hasNextPage && (
                 <LoadMoreButton

--- a/src/components/QueriedStreamsTable.tsx
+++ b/src/components/QueriedStreamsTable.tsx
@@ -12,7 +12,7 @@ import {
 } from '~/hooks/streams'
 import { ScrollTableCore } from '~/shared/components/ScrollTable/ScrollTable'
 import { OrderDirection } from '~/types'
-import { useCurrentChainId, useCurrentChainSymbolicName } from '~/utils/chains'
+import { useCurrentChainId, useCurrentChainKey } from '~/utils/chains'
 import { Route as R, routeOptions } from '~/utils/routes'
 
 interface Props {
@@ -42,7 +42,7 @@ export function QueriedStreamsTable({
 
     const chainId = useCurrentChainId()
 
-    const chainName = useCurrentChainSymbolicName()
+    const chainName = useCurrentChainKey()
 
     const indexerQueryErrored = query.isError && isIndexerColumn(chainId, orderBy)
 

--- a/src/getters/getEnvironmentConfig.ts
+++ b/src/getters/getEnvironmentConfig.ts
@@ -1,3 +1,4 @@
+import { Chain } from '@streamr/config'
 import { z } from 'zod'
 import config from '~/config/environments.toml'
 import { defaultChainKey } from '~/consts'
@@ -15,25 +16,19 @@ const EnvironmentConfig = z
             !defaultChain || availableChains.includes(defaultChain),
         'Default chain is not listed in the collection of available chains',
     )
-    .transform(
-        ({
-            availableChains: symbolicChainNames,
-            defaultChain: defaultSymbolicChainName,
-            ...rest
-        }) => {
-            const availableChains = symbolicChainNames.map(getChainConfig)
+    .transform(({ availableChains, defaultChain, ...rest }) => {
+        const availableChainConfigs: Chain[] = availableChains.map(getChainConfig)
 
-            const defaultChain = defaultSymbolicChainName
-                ? getChainConfig(defaultSymbolicChainName)
-                : availableChains[0]
+        const defaultChainConfig: Chain = defaultChain
+            ? getChainConfig(defaultChain)
+            : availableChainConfigs[0]
 
-            return {
-                ...rest,
-                availableChains,
-                defaultChain,
-            }
-        },
-    )
+        return {
+            ...rest,
+            availableChains: availableChainConfigs,
+            defaultChain: defaultChainConfig,
+        }
+    })
 
 type EnvironmentConfig = z.infer<typeof EnvironmentConfig>
 

--- a/src/marketplace/components/ProjectTypeChooser/index.tsx
+++ b/src/marketplace/components/ProjectTypeChooser/index.tsx
@@ -176,15 +176,15 @@ export const ProjectTypeChooser: FunctionComponent<{
 }> = ({ className, onClose }) => {
     const [selectedProductType, setSelectedProductType] = useState<ProjectType>()
 
-    const chainName = useCurrentChainKey()
+    const chainKey = useCurrentChainKey()
 
     const link = useMemo<string | null>(() => {
         if (!selectedProductType) {
             return null
         }
 
-        return R.project('new', routeOptions(chainName, { type: selectedProductType }))
-    }, [selectedProductType, chainName])
+        return R.project('new', routeOptions(chainKey, { type: selectedProductType }))
+    }, [selectedProductType, chainKey])
 
     const gotAnyStreams = useGotAnyStreams()
 
@@ -268,7 +268,7 @@ export const ProjectTypeChooser: FunctionComponent<{
             {gotAnyStreams === false && (
                 <NoStreamsWarningBox>
                     You have not created any streams yet. Please{' '}
-                    <Link onClick={onClose} to={R.stream('new', routeOptions(chainName))}>
+                    <Link onClick={onClose} to={R.stream('new', routeOptions(chainKey))}>
                         create a stream
                     </Link>{' '}
                     to get started. For help creating streams, see the{' '}

--- a/src/marketplace/components/ProjectTypeChooser/index.tsx
+++ b/src/marketplace/components/ProjectTypeChooser/index.tsx
@@ -15,7 +15,7 @@ import SvgIcon from '~/shared/components/SvgIcon'
 import { useWalletAccount } from '~/shared/stores/wallet'
 import { ProjectType } from '~/shared/types'
 import { COLORS, DESKTOP, REGULAR } from '~/shared/utils/styled'
-import { useCurrentChainId, useCurrentChainSymbolicName } from '~/utils/chains'
+import { useCurrentChainId, useCurrentChainKey } from '~/utils/chains'
 import { Route as R, routeOptions } from '~/utils/routes'
 
 const Root = styled.div`
@@ -176,7 +176,7 @@ export const ProjectTypeChooser: FunctionComponent<{
 }> = ({ className, onClose }) => {
     const [selectedProductType, setSelectedProductType] = useState<ProjectType>()
 
-    const chainName = useCurrentChainSymbolicName()
+    const chainName = useCurrentChainKey()
 
     const link = useMemo<string | null>(() => {
         if (!selectedProductType) {

--- a/src/pages/GenericErrorPage.tsx
+++ b/src/pages/GenericErrorPage.tsx
@@ -7,7 +7,7 @@ import Layout from '~/components/Layout'
 import { ParseError } from '~/errors'
 import appCrashedImage from '~/shared/assets/images/app_crashed.png'
 import appCrashedImage2x from '~/shared/assets/images/app_crashed@2x.png'
-import { useCurrentChainSymbolicName } from '~/utils/chains'
+import { useCurrentChainKey } from '~/utils/chains'
 import { Route as R, routeOptions } from '~/utils/routes'
 
 export default function GenericErrorPage() {
@@ -62,7 +62,7 @@ function ParseErrorPage() {
 }
 
 export function GenericErrorPageContent() {
-    const chainName = useCurrentChainSymbolicName()
+    const chainName = useCurrentChainKey()
     return (
         <Root>
             <EmptyState

--- a/src/pages/GenericErrorPage.tsx
+++ b/src/pages/GenericErrorPage.tsx
@@ -62,7 +62,8 @@ function ParseErrorPage() {
 }
 
 export function GenericErrorPageContent() {
-    const chainName = useCurrentChainKey()
+    const chainKey = useCurrentChainKey()
+
     return (
         <Root>
             <EmptyState
@@ -77,7 +78,7 @@ export function GenericErrorPageContent() {
                     <Button
                         kind="special"
                         as={Link}
-                        to={R.projects(routeOptions(chainName))}
+                        to={R.projects(routeOptions(chainKey))}
                         className="d-none d-md-flex"
                     >
                         Projects

--- a/src/pages/NetworkOverviewPage.tsx
+++ b/src/pages/NetworkOverviewPage.tsx
@@ -270,7 +270,7 @@ function MyOperatorSummary() {
 
     const chartLabel = chartId === 'stake' ? 'Total stake' : 'Cumulative earnings'
 
-    const chainName = useCurrentChainKey()
+    const chainKey = useCurrentChainKey()
 
     return (
         <NetworkPageSegment
@@ -281,7 +281,7 @@ function MyOperatorSummary() {
                             <Button
                                 kind="secondary"
                                 as={Link}
-                                to={R.operator(operator.id, routeOptions(chainName))}
+                                to={R.operator(operator.id, routeOptions(chainKey))}
                             >
                                 View Operator
                             </Button>
@@ -355,7 +355,7 @@ function MyOperatorSummary() {
                                 secondLine={
                                     <>
                                         You can become an operator on the{' '}
-                                        <Link to={R.operators(routeOptions(chainName))}>
+                                        <Link to={R.operators(routeOptions(chainKey))}>
                                             Operators
                                         </Link>{' '}
                                         page.
@@ -498,7 +498,7 @@ function MyDelegations() {
             .flatMap((page) => page.elements)
             .filter((d) => d.contractVersion !== 1) || []
 
-    const chainName = useCurrentChainKey()
+    const chainKey = useCurrentChainKey()
 
     return (
         <NetworkPageSegment title="My delegations" foot>
@@ -575,7 +575,7 @@ function MyDelegations() {
                                 },
                             ]}
                             linkMapper={({ id }) =>
-                                R.operator(id, routeOptions(chainName))
+                                R.operator(id, routeOptions(chainKey))
                             }
                         />
                         {query.hasNextPage ? (
@@ -596,7 +596,7 @@ function MyDelegations() {
                         secondLine={
                             <>
                                 You can browse{' '}
-                                <Link to={R.operators(routeOptions(chainName))}>
+                                <Link to={R.operators(routeOptions(chainKey))}>
                                     operators
                                 </Link>{' '}
                                 to start delegating.
@@ -613,7 +613,7 @@ function MyDelegations() {
 function MySponsorships() {
     const query = useSponsorshipsForCreatorQuery(useWalletAccount())
 
-    const chainName = useCurrentChainKey()
+    const chainKey = useCurrentChainKey()
 
     return (
         <NetworkPageSegment title="My sponsorships" foot>
@@ -624,7 +624,7 @@ function MySponsorships() {
                     noDataSecondLine={
                         <>
                             You can{' '}
-                            <Link to={R.sponsorships(routeOptions(chainName))}>
+                            <Link to={R.sponsorships(routeOptions(chainKey))}>
                                 start a sponsorship
                             </Link>{' '}
                             here

--- a/src/pages/NetworkOverviewPage.tsx
+++ b/src/pages/NetworkOverviewPage.tsx
@@ -57,7 +57,7 @@ import { useWalletAccount } from '~/shared/stores/wallet'
 import { ChartPeriod, XY } from '~/types'
 import { abbr } from '~/utils'
 import { toBigInt, toFloat } from '~/utils/bn'
-import { useCurrentChainId, useCurrentChainSymbolicName } from '~/utils/chains'
+import { useCurrentChainId, useCurrentChainKey } from '~/utils/chains'
 import { Route as R, routeOptions } from '~/utils/routes'
 import { errorToast } from '~/utils/toast'
 
@@ -270,7 +270,7 @@ function MyOperatorSummary() {
 
     const chartLabel = chartId === 'stake' ? 'Total stake' : 'Cumulative earnings'
 
-    const chainName = useCurrentChainSymbolicName()
+    const chainName = useCurrentChainKey()
 
     return (
         <NetworkPageSegment
@@ -498,7 +498,7 @@ function MyDelegations() {
             .flatMap((page) => page.elements)
             .filter((d) => d.contractVersion !== 1) || []
 
-    const chainName = useCurrentChainSymbolicName()
+    const chainName = useCurrentChainKey()
 
     return (
         <NetworkPageSegment title="My delegations" foot>
@@ -613,7 +613,7 @@ function MyDelegations() {
 function MySponsorships() {
     const query = useSponsorshipsForCreatorQuery(useWalletAccount())
 
-    const chainName = useCurrentChainSymbolicName()
+    const chainName = useCurrentChainKey()
 
     return (
         <NetworkPageSegment title="My sponsorships" foot>

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -18,7 +18,7 @@ export default function NotFoundPage() {
 }
 
 export function NotFoundPageContent() {
-    const chainName = useCurrentChainKey()
+    const chainKey = useCurrentChainKey()
 
     const fullChainName = useCurrentChainFullName()
 
@@ -37,14 +37,14 @@ export function NotFoundPageContent() {
                         <Button
                             kind="special"
                             as={Link}
-                            to={R.streams(routeOptions(chainName))}
+                            to={R.streams(routeOptions(chainKey))}
                         >
                             Go to streams
                         </Button>
                         <Button
                             kind="special"
                             as={Link}
-                            to={R.projects(routeOptions(chainName))}
+                            to={R.projects(routeOptions(chainKey))}
                         >
                             Go to projects
                         </Button>

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
 import styled from 'styled-components'
+import { Button } from '~/components/Button'
 import { EmptyState } from '~/components/EmptyState'
 import Layout from '~/components/Layout'
 import pageNotFoundPic from '~/shared/assets/images/404_blocks.png'
 import pageNotFoundPic2x from '~/shared/assets/images/404_blocks@2x.png'
-import { Button } from '~/components/Button'
+import { useCurrentChainFullName, useCurrentChainKey } from '~/utils/chains'
 import { Route as R, routeOptions } from '~/utils/routes'
-import { useCurrentChainFullName, useCurrentChainSymbolicName } from '~/utils/chains'
 
 export default function NotFoundPage() {
     return (
@@ -18,7 +18,7 @@ export default function NotFoundPage() {
 }
 
 export function NotFoundPageContent() {
-    const chainName = useCurrentChainSymbolicName()
+    const chainName = useCurrentChainKey()
 
     const fullChainName = useCurrentChainFullName()
 

--- a/src/pages/OperatorPage/OperatorActionBar.tsx
+++ b/src/pages/OperatorPage/OperatorActionBar.tsx
@@ -43,7 +43,7 @@ export function OperatorActionBar({ operator }: OperatorActionBarProps) {
 
     const currentChainId = useCurrentChainId()
 
-    const chainName = useCurrentChainKey()
+    const chainKey = useCurrentChainKey()
 
     const canUndelegateQuery = useQuery({
         queryKey: [
@@ -94,7 +94,7 @@ export function OperatorActionBar({ operator }: OperatorActionBarProps) {
                 <OuterWrap>
                     <Wrap0>
                         <NetworkActionBarBackLink
-                            to={R.operators(routeOptions(chainName))}
+                            to={R.operators(routeOptions(chainKey))}
                             onClick={(e) => {
                                 goBack({
                                     onBeforeNavigate() {

--- a/src/pages/OperatorPage/OperatorActionBar.tsx
+++ b/src/pages/OperatorPage/OperatorActionBar.tsx
@@ -20,7 +20,7 @@ import { getOperatorDelegationAmount } from '~/services/operators'
 import { useWalletAccount } from '~/shared/stores/wallet'
 import { COLORS, DESKTOP, TABLET } from '~/shared/utils/styled'
 import { goBack } from '~/utils'
-import { useCurrentChainId, useCurrentChainSymbolicName } from '~/utils/chains'
+import { useCurrentChainId, useCurrentChainKey } from '~/utils/chains'
 import { Route as R, routeOptions } from '~/utils/routes'
 
 interface OperatorActionBarProps {
@@ -43,7 +43,7 @@ export function OperatorActionBar({ operator }: OperatorActionBarProps) {
 
     const currentChainId = useCurrentChainId()
 
-    const chainName = useCurrentChainSymbolicName()
+    const chainName = useCurrentChainKey()
 
     const canUndelegateQuery = useQuery({
         queryKey: [

--- a/src/pages/OperatorPage/SponsorshipTable.tsx
+++ b/src/pages/OperatorPage/SponsorshipTable.tsx
@@ -33,7 +33,7 @@ export function SponsorshipTable({
 
     const currentChainId = useCurrentChainId()
 
-    const chainName = useCurrentChainKey()
+    const chainKey = useCurrentChainKey()
 
     const allSponsorshipIds = operator.stakes.map(({ sponsorshipId }) => sponsorshipId)
 
@@ -125,7 +125,7 @@ export function SponsorshipTable({
                 },
             ]}
             linkMapper={({ sponsorshipId: id }) =>
-                R.sponsorship(id, routeOptions(chainName))
+                R.sponsorship(id, routeOptions(chainKey))
             }
             actions={[
                 (element) => ({

--- a/src/pages/OperatorPage/SponsorshipTable.tsx
+++ b/src/pages/OperatorPage/SponsorshipTable.tsx
@@ -1,22 +1,22 @@
-import React from 'react'
 import moment from 'moment'
+import React from 'react'
 import styled from 'styled-components'
+import { Button } from '~/components/Button'
 import { SponsorshipDecimals } from '~/components/Decimals'
 import Spinner from '~/components/Spinner'
 import { FundedUntilCell, StreamIdCell } from '~/components/Table'
 import { Tooltip, TooltipIconWrap } from '~/components/Tooltip'
+import { useCollectEarnings } from '~/hooks/operators'
+import { useEditSponsorshipFunding } from '~/hooks/sponsorships'
 import { Operator } from '~/parsers/Operator'
 import { ScrollTable } from '~/shared/components/ScrollTable/ScrollTable'
 import SvgIcon from '~/shared/components/SvgIcon'
-import { Route as R, routeOptions } from '~/utils/routes'
 import {
     useCanCollectEarningsCallback,
     useUncollectedEarnings,
 } from '~/shared/stores/uncollectedEarnings'
-import { useCollectEarnings } from '~/hooks/operators'
-import { useEditSponsorshipFunding } from '~/hooks/sponsorships'
-import { Button } from '~/components/Button'
-import { useCurrentChainId, useCurrentChainSymbolicName } from '~/utils/chains'
+import { useCurrentChainId, useCurrentChainKey } from '~/utils/chains'
+import { Route as R, routeOptions } from '~/utils/routes'
 
 export function SponsorshipTable({
     operator,
@@ -33,7 +33,7 @@ export function SponsorshipTable({
 
     const currentChainId = useCurrentChainId()
 
-    const chainName = useCurrentChainSymbolicName()
+    const chainName = useCurrentChainKey()
 
     const allSponsorshipIds = operator.stakes.map(({ sponsorshipId }) => sponsorshipId)
 

--- a/src/pages/OperatorPage/index.tsx
+++ b/src/pages/OperatorPage/index.tsx
@@ -125,7 +125,7 @@ export const OperatorPage = () => {
 
     const currentChainId = useCurrentChainId()
 
-    const chainName = useCurrentChainKey()
+    const chainKey = useCurrentChainKey()
 
     const earliestUndelegationTimestamp = operator?.delegations.find(
         (d) => d.delegator.toLowerCase() === walletAddress?.toLowerCase(),
@@ -579,7 +579,7 @@ export const OperatorPage = () => {
                                         },
                                     ]}
                                     linkMapper={({ sponsorshipId: id }) =>
-                                        R.sponsorship(id, routeOptions(chainName))
+                                        R.sponsorship(id, routeOptions(chainKey))
                                     }
                                 />
                             </SlashingHistoryTableContainer>

--- a/src/pages/OperatorPage/index.tsx
+++ b/src/pages/OperatorPage/index.tsx
@@ -46,8 +46,8 @@ import { OperatorActionBar } from '~/pages/OperatorPage/OperatorActionBar'
 import { OperatorChecklist } from '~/pages/OperatorPage/OperatorChecklist'
 import { OperatorDetails } from '~/pages/OperatorPage/OperatorDetails'
 import { OperatorSummary } from '~/pages/OperatorPage/OperatorSummary'
-import { UndelegationQueue } from '~/pages/OperatorPage/UndelegationQueue'
 import { SponsorshipTable } from '~/pages/OperatorPage/SponsorshipTable'
+import { UndelegationQueue } from '~/pages/OperatorPage/UndelegationQueue'
 import LoadingIndicator from '~/shared/components/LoadingIndicator'
 import { NoData } from '~/shared/components/NoData'
 import { ScrollTable } from '~/shared/components/ScrollTable/ScrollTable'
@@ -68,7 +68,7 @@ import { toBN, toBigInt, toFloat } from '~/utils/bn'
 import {
     useCurrentChainFullName,
     useCurrentChainId,
-    useCurrentChainSymbolicName,
+    useCurrentChainKey,
 } from '~/utils/chains'
 import { Route as R, routeOptions } from '~/utils/routes'
 import { errorToast } from '~/utils/toast'
@@ -125,7 +125,7 @@ export const OperatorPage = () => {
 
     const currentChainId = useCurrentChainId()
 
-    const chainName = useCurrentChainSymbolicName()
+    const chainName = useCurrentChainKey()
 
     const earliestUndelegationTimestamp = operator?.delegations.find(
         (d) => d.delegator.toLowerCase() === walletAddress?.toLowerCase(),

--- a/src/pages/OperatorsPage.tsx
+++ b/src/pages/OperatorsPage.tsx
@@ -97,7 +97,7 @@ export const OperatorsPage = () => {
 
     const chainId = useCurrentChainId()
 
-    const chainName = useCurrentChainKey()
+    const chainKey = useCurrentChainKey()
 
     const operatorQuery = useOperatorForWalletQuery(wallet)
 
@@ -112,13 +112,13 @@ export const OperatorsPage = () => {
         if (!wallet && !isWalletLoading) {
             navigate(
                 R.operators(
-                    routeOptions(chainName, {
+                    routeOptions(chainKey, {
                         tab: TabOption.AllOperators,
                     }),
                 ),
             )
         }
-    }, [wallet, isWalletLoading, navigate, chainName])
+    }, [wallet, isWalletLoading, navigate, chainKey])
 
     return (
         <Layout>
@@ -130,7 +130,7 @@ export const OperatorsPage = () => {
                 leftSideContent={
                     <Tabs
                         onSelectionChange={(value) => {
-                            navigate(R.operators(routeOptions(chainName, { tab: value })))
+                            navigate(R.operators(routeOptions(chainKey, { tab: value })))
                         }}
                         selection={selectedTab}
                         fullWidthOnMobile={true}
@@ -145,7 +145,7 @@ export const OperatorsPage = () => {
                     operator ? (
                         <Button
                             as={Link}
-                            to={R.operator(operator.id, routeOptions(chainName))}
+                            to={R.operator(operator.id, routeOptions(chainKey))}
                         >
                             View my Operator
                         </Button>
@@ -226,7 +226,7 @@ function DelegationsTable({
             .flatMap((page) => page.elements)
             .filter((d) => d.contractVersion !== 1) || []
 
-    const chainName = useCurrentChainKey()
+    const chainKey = useCurrentChainKey()
 
     const chainFullName = useCurrentChainFullName()
 
@@ -294,7 +294,7 @@ function DelegationsTable({
                 },
             ]}
             noDataFirstLine={`You have not delegated to any operator on the ${chainFullName} chain.`}
-            linkMapper={(element) => R.operator(element.id, routeOptions(chainName))}
+            linkMapper={(element) => R.operator(element.id, routeOptions(chainKey))}
         />
     )
 }
@@ -312,7 +312,7 @@ function OperatorsTable({
 }) {
     const elements = query.data?.pages.flatMap((page) => page.elements) || []
 
-    const chainName = useCurrentChainKey()
+    const chainKey = useCurrentChainKey()
 
     const chainFullName = useCurrentChainFullName()
 
@@ -385,7 +385,7 @@ function OperatorsTable({
                 },
             ]}
             noDataFirstLine={`No operators found on the ${chainFullName} chain.`}
-            linkMapper={(element) => R.operator(element.id, routeOptions(chainName))}
+            linkMapper={(element) => R.operator(element.id, routeOptions(chainKey))}
         />
     )
 }

--- a/src/pages/OperatorsPage.tsx
+++ b/src/pages/OperatorsPage.tsx
@@ -16,6 +16,7 @@ import {
     useOperatorForWalletQuery,
 } from '~/hooks/operators'
 import { useTableOrder } from '~/hooks/useTableOrder'
+import { useUrlParams } from '~/hooks/useUrlParams'
 import { Operator } from '~/parsers/Operator'
 import { ScrollTableCore } from '~/shared/components/ScrollTable/ScrollTable'
 import Tabs, { Tab } from '~/shared/components/Tabs'
@@ -25,10 +26,9 @@ import { saveOperator } from '~/utils'
 import {
     useCurrentChainFullName,
     useCurrentChainId,
-    useCurrentChainSymbolicName,
+    useCurrentChainKey,
 } from '~/utils/chains'
 import { Route as R, routeOptions } from '~/utils/routes'
-import { useUrlParams } from '~/hooks/useUrlParams'
 
 enum TabOption {
     AllOperators = 'all',
@@ -97,7 +97,7 @@ export const OperatorsPage = () => {
 
     const chainId = useCurrentChainId()
 
-    const chainName = useCurrentChainSymbolicName()
+    const chainName = useCurrentChainKey()
 
     const operatorQuery = useOperatorForWalletQuery(wallet)
 
@@ -226,7 +226,7 @@ function DelegationsTable({
             .flatMap((page) => page.elements)
             .filter((d) => d.contractVersion !== 1) || []
 
-    const chainName = useCurrentChainSymbolicName()
+    const chainName = useCurrentChainKey()
 
     const chainFullName = useCurrentChainFullName()
 
@@ -312,7 +312,7 @@ function OperatorsTable({
 }) {
     const elements = query.data?.pages.flatMap((page) => page.elements) || []
 
-    const chainName = useCurrentChainSymbolicName()
+    const chainName = useCurrentChainKey()
 
     const chainFullName = useCurrentChainFullName()
 

--- a/src/pages/ProjectPage/AccessManifest.tsx
+++ b/src/pages/ProjectPage/AccessManifest.tsx
@@ -45,7 +45,7 @@ export function AccessManifest({
 
     const { pricePerSecond, chainId, pricingTokenAddress } = firstSalePoint
 
-    const chainName = useCurrentChainKey()
+    const chainKey = useCurrentChainKey()
 
     return (
         <Root>
@@ -78,7 +78,7 @@ export function AccessManifest({
             {hasAccess === true && (
                 <Button
                     as={Link}
-                    to={R.projectConnect(projectId, routeOptions(chainName))}
+                    to={R.projectConnect(projectId, routeOptions(chainKey))}
                 >
                     Connect
                 </Button>

--- a/src/pages/ProjectPage/AccessManifest.tsx
+++ b/src/pages/ProjectPage/AccessManifest.tsx
@@ -14,11 +14,7 @@ import { REGULAR, TABLET } from '~/shared/utils/styled'
 import { timeUnits } from '~/shared/utils/timeUnit'
 import { useIsAccessibleByCurrentWallet } from '~/stores/projectDraft'
 import { formatChainName } from '~/utils'
-import {
-    getChainConfig,
-    useCurrentChainId,
-    useCurrentChainSymbolicName,
-} from '~/utils/chains'
+import { getChainConfig, useCurrentChainId, useCurrentChainKey } from '~/utils/chains'
 import { Route as R, routeOptions } from '~/utils/routes'
 import { errorToast } from '~/utils/toast'
 
@@ -49,7 +45,7 @@ export function AccessManifest({
 
     const { pricePerSecond, chainId, pricingTokenAddress } = firstSalePoint
 
-    const chainName = useCurrentChainSymbolicName()
+    const chainName = useCurrentChainKey()
 
     return (
         <Root>

--- a/src/pages/ProjectPage/EditorNav.tsx
+++ b/src/pages/ProjectPage/EditorNav.tsx
@@ -45,7 +45,7 @@ export default function EditorNav() {
 
     const [attach, isSaveButtonVisible] = useInViewport()
 
-    const chainName = useCurrentChainKey()
+    const chainKey = useCurrentChainKey()
 
     return (
         <NavContainer>
@@ -53,7 +53,7 @@ export default function EditorNav() {
                 <FlexNavbarItem>
                     <Button
                         as={Link}
-                        to={R.projects(routeOptions(chainName))}
+                        to={R.projects(routeOptions(chainKey))}
                         kind="transparent"
                     >
                         Exit
@@ -77,7 +77,7 @@ export default function EditorNav() {
                 <FlexNavbarItem>
                     <Button
                         as={Link}
-                        to={R.projects(routeOptions(chainName))}
+                        to={R.projects(routeOptions(chainKey))}
                         kind="transparent"
                     >
                         Exit

--- a/src/pages/ProjectPage/EditorNav.tsx
+++ b/src/pages/ProjectPage/EditorNav.tsx
@@ -1,16 +1,16 @@
 import React from 'react'
-import styled from 'styled-components'
 import { Link } from 'react-router-dom'
+import styled from 'styled-components'
+import { Button } from '~/components/Button'
+import { FloatingToolbar } from '~/components/FloatingToolbar'
 import { NavContainer } from '~/components/Nav'
 import { LogoLink, Navbar, NavbarItem } from '~/components/Nav/Nav.styles'
+import { useInViewport } from '~/hooks/useInViewport'
 import Logo from '~/shared/components/Logo'
-import { Button } from '~/components/Button'
 import { REGULAR } from '~/shared/utils/styled'
 import { ProjectDraft, usePersistProjectCallback } from '~/stores/projectDraft'
-import { FloatingToolbar } from '~/components/FloatingToolbar'
-import { useInViewport } from '~/hooks/useInViewport'
+import { useCurrentChainKey } from '~/utils/chains'
 import { Route as R, routeOptions } from '~/utils/routes'
-import { useCurrentChainSymbolicName } from '~/utils/chains'
 
 const FlexNavbar = styled(Navbar)`
     display: flex;
@@ -45,7 +45,7 @@ export default function EditorNav() {
 
     const [attach, isSaveButtonVisible] = useInViewport()
 
-    const chainName = useCurrentChainSymbolicName()
+    const chainName = useCurrentChainKey()
 
     return (
         <NavContainer>

--- a/src/pages/ProjectPage/ProjectLinkTabs.tsx
+++ b/src/pages/ProjectPage/ProjectLinkTabs.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 import { Link, useLocation } from 'react-router-dom'
-import isPreventable from '~/utils/isPreventable'
 import Tabs, { Tab } from '~/shared/components/Tabs'
+import { useCurrentChainKey } from '~/utils/chains'
+import isPreventable from '~/utils/isPreventable'
 import { Route as R, routeOptions } from '~/utils/routes'
-import { useCurrentChainSymbolicName } from '~/utils/chains'
 
 export default function ProjectLinkTabs({
     projectId,
@@ -14,7 +14,7 @@ export default function ProjectLinkTabs({
 }) {
     const { pathname } = useLocation()
 
-    const chainName = useCurrentChainSymbolicName()
+    const chainName = useCurrentChainKey()
 
     if (!projectId || disabled) {
         return (

--- a/src/pages/ProjectPage/ProjectLinkTabs.tsx
+++ b/src/pages/ProjectPage/ProjectLinkTabs.tsx
@@ -14,7 +14,7 @@ export default function ProjectLinkTabs({
 }) {
     const { pathname } = useLocation()
 
-    const chainName = useCurrentChainKey()
+    const chainKey = useCurrentChainKey()
 
     if (!projectId || disabled) {
         return (
@@ -47,7 +47,7 @@ export default function ProjectLinkTabs({
             <Tab
                 id="overview"
                 tag={Link}
-                to={R.projectOverview(projectId, routeOptions(chainName))}
+                to={R.projectOverview(projectId, routeOptions(chainKey))}
                 selected={pathname.startsWith(R.projectOverview(projectId))}
             >
                 Project overview
@@ -55,7 +55,7 @@ export default function ProjectLinkTabs({
             <Tab
                 id="connect"
                 tag={Link}
-                to={R.projectConnect(projectId, routeOptions(chainName))}
+                to={R.projectConnect(projectId, routeOptions(chainKey))}
                 selected={pathname.startsWith(R.projectConnect(projectId))}
             >
                 Connect
@@ -63,7 +63,7 @@ export default function ProjectLinkTabs({
             <Tab
                 id="liveData"
                 tag={Link}
-                to={R.projectLiveData(projectId, routeOptions(chainName))}
+                to={R.projectLiveData(projectId, routeOptions(chainKey))}
                 selected={pathname.startsWith(R.projectLiveData(projectId))}
             >
                 Live data

--- a/src/pages/ProjectPage/index.tsx
+++ b/src/pages/ProjectPage/index.tsx
@@ -295,12 +295,12 @@ export function ProjectTabbedPage() {
 
     const canEdit = useCurrentProjectAbility(ProjectPermission.Edit)
 
-    const chainName = useCurrentChainKey()
+    const chainKey = useCurrentChainKey()
 
     return (
         <Layout pageTitle={name}>
             <DetailsPageHeader
-                backButtonLink={R.projects(routeOptions(chainName))}
+                backButtonLink={R.projects(routeOptions(chainKey))}
                 pageTitle={
                     <PageTitleContainer>
                         <ProjectTitle>
@@ -315,7 +315,7 @@ export function ProjectTabbedPage() {
                         {canEdit && (
                             <EditButton
                                 as={Link}
-                                to={R.projectEdit(id, routeOptions(chainName))}
+                                to={R.projectEdit(id, routeOptions(chainKey))}
                                 kind="secondary"
                                 size="mini"
                             >

--- a/src/pages/ProjectPage/index.tsx
+++ b/src/pages/ProjectPage/index.tsx
@@ -36,8 +36,8 @@ import {
     useIsAccessibleByCurrentWallet,
 } from '~/stores/projectDraft'
 import { isProjectType } from '~/utils'
+import { useCurrentChainKey } from '~/utils/chains'
 import { Route as R, routeOptions } from '~/utils/routes'
-import { useCurrentChainSymbolicName } from '~/utils/chains'
 import { AccessManifest } from './AccessManifest'
 import GetAccess from './GetAccess'
 import ProjectEditorPage from './ProjectEditorPage'
@@ -295,7 +295,7 @@ export function ProjectTabbedPage() {
 
     const canEdit = useCurrentProjectAbility(ProjectPermission.Edit)
 
-    const chainName = useCurrentChainSymbolicName()
+    const chainName = useCurrentChainKey()
 
     return (
         <Layout pageTitle={name}>

--- a/src/pages/SingleSponsorshipPage.tsx
+++ b/src/pages/SingleSponsorshipPage.tsx
@@ -41,7 +41,7 @@ import { COLORS, LAPTOP, TABLET } from '~/shared/utils/styled'
 import { truncate } from '~/shared/utils/text'
 import { ChartPeriod } from '~/types'
 import { abbr } from '~/utils'
-import { useCurrentChainFullName, useCurrentChainSymbolicName } from '~/utils/chains'
+import { useCurrentChainFullName, useCurrentChainKey } from '~/utils/chains'
 import { Route as R, routeOptions } from '~/utils/routes'
 
 const EmptyArray = []
@@ -145,7 +145,7 @@ export const SingleSponsorshipPage = () => {
         <NoData firstLine={`Sponsorship not found on the ${fullChainName} chain.`} />
     ) : null
 
-    const chainName = useCurrentChainSymbolicName()
+    const chainName = useCurrentChainKey()
 
     const rawFundingEvents = fundingEventsQuery.data?.pages || EmptyArray
 

--- a/src/pages/SingleSponsorshipPage.tsx
+++ b/src/pages/SingleSponsorshipPage.tsx
@@ -145,7 +145,7 @@ export const SingleSponsorshipPage = () => {
         <NoData firstLine={`Sponsorship not found on the ${fullChainName} chain.`} />
     ) : null
 
-    const chainName = useCurrentChainKey()
+    const chainKey = useCurrentChainKey()
 
     const rawFundingEvents = fundingEventsQuery.data?.pages || EmptyArray
 
@@ -266,7 +266,7 @@ export const SingleSponsorshipPage = () => {
                                                 <Link
                                                     to={R.operator(
                                                         stake.operatorId,
-                                                        routeOptions(chainName),
+                                                        routeOptions(chainKey),
                                                     )}
                                                 >
                                                     <div>

--- a/src/pages/SponsorshipsPage.tsx
+++ b/src/pages/SponsorshipsPage.tsx
@@ -118,19 +118,19 @@ export const SponsorshipsPage = () => {
 
     const navigate = useNavigate()
 
-    const chainName = useCurrentChainKey()
+    const chainKey = useCurrentChainKey()
 
     useEffect(() => {
         if (!wallet && !isWalletLoading) {
             navigate(
                 R.sponsorships(
-                    routeOptions(chainName, {
+                    routeOptions(chainKey, {
                         tab: TabOption.AllSponsorships,
                     }),
                 ),
             )
         }
-    }, [wallet, navigate, chainName, isWalletLoading])
+    }, [wallet, navigate, chainKey, isWalletLoading])
 
     const createSponsorship = useCreateSponsorship()
 
@@ -151,7 +151,7 @@ export const SponsorshipsPage = () => {
                     <Tabs
                         onSelectionChange={(value) => {
                             navigate(
-                                R.sponsorships(routeOptions(chainName, { tab: value })),
+                                R.sponsorships(routeOptions(chainKey, { tab: value })),
                             )
                         }}
                         selection={selectedTab}

--- a/src/pages/SponsorshipsPage.tsx
+++ b/src/pages/SponsorshipsPage.tsx
@@ -19,16 +19,16 @@ import {
     useSponsorshipsForCreatorQuery,
 } from '~/hooks/sponsorships'
 import { useTableOrder } from '~/hooks/useTableOrder'
+import { useUrlParams } from '~/hooks/useUrlParams'
 import Tabs, { Tab } from '~/shared/components/Tabs'
-import { useWalletAccount, useIsWalletLoading } from '~/shared/stores/wallet'
+import { useIsWalletLoading, useWalletAccount } from '~/shared/stores/wallet'
+import { OrderDirection } from '~/types'
 import {
     useCurrentChainFullName,
     useCurrentChainId,
-    useCurrentChainSymbolicName,
+    useCurrentChainKey,
 } from '~/utils/chains'
 import { Route as R, routeOptions } from '~/utils/routes'
-import { useUrlParams } from '~/hooks/useUrlParams'
-import { OrderDirection } from '~/types'
 
 enum TabOption {
     AllSponsorships = 'all',
@@ -118,7 +118,7 @@ export const SponsorshipsPage = () => {
 
     const navigate = useNavigate()
 
-    const chainName = useCurrentChainSymbolicName()
+    const chainName = useCurrentChainKey()
 
     useEffect(() => {
         if (!wallet && !isWalletLoading) {

--- a/src/pages/StreamPage/index.tsx
+++ b/src/pages/StreamPage/index.tsx
@@ -360,7 +360,7 @@ function Header({
 
     const ready = !!entity
 
-    const chainName = useCurrentChainKey()
+    const chainKey = useCurrentChainKey()
 
     return (
         <>
@@ -370,7 +370,7 @@ function Header({
                 }
             />
             <DetailsPageHeader
-                backButtonLink={R.streams(routeOptions(chainName))}
+                backButtonLink={R.streams(routeOptions(chainKey))}
                 pageTitle={
                     <TitleContainer>
                         <span title={streamId}>
@@ -393,7 +393,7 @@ function Header({
                             <Tab
                                 id="overview"
                                 tag={Link}
-                                to={R.streamOverview(streamId, routeOptions(chainName))}
+                                to={R.streamOverview(streamId, routeOptions(chainKey))}
                                 selected={location.pathname.startsWith(
                                     R.streamOverview(streamId),
                                 )}
@@ -404,7 +404,7 @@ function Header({
                             <Tab
                                 id="connect"
                                 tag={Link}
-                                to={R.streamConnect(streamId, routeOptions(chainName))}
+                                to={R.streamConnect(streamId, routeOptions(chainKey))}
                                 selected={location.pathname.startsWith(
                                     R.streamConnect(streamId),
                                 )}
@@ -414,7 +414,7 @@ function Header({
                             <Tab
                                 id="liveData"
                                 tag={Link}
-                                to={R.streamLiveData(streamId, routeOptions(chainName))}
+                                to={R.streamLiveData(streamId, routeOptions(chainKey))}
                                 selected={location.pathname.startsWith(
                                     R.streamLiveData(streamId),
                                 )}

--- a/src/pages/StreamPage/index.tsx
+++ b/src/pages/StreamPage/index.tsx
@@ -37,7 +37,7 @@ import {
     usePersistStreamDraft,
     useStreamEntityQuery,
 } from '~/stores/streamDraft'
-import { useCurrentChainSymbolicName } from '~/utils/chains'
+import { useCurrentChainKey } from '~/utils/chains'
 import { Route as R, routeOptions } from '~/utils/routes'
 import { AccessControlSection } from '../AbstractStreamEditPage/AccessControlSection'
 import CreateProjectHint from '../AbstractStreamEditPage/CreateProjectHint'
@@ -360,7 +360,7 @@ function Header({
 
     const ready = !!entity
 
-    const chainName = useCurrentChainSymbolicName()
+    const chainName = useCurrentChainKey()
 
     return (
         <>

--- a/src/pages/StreamsPage.tsx
+++ b/src/pages/StreamsPage.tsx
@@ -21,14 +21,14 @@ import {
     useStreamsQuery,
 } from '~/hooks/streams'
 import { useTableOrder } from '~/hooks/useTableOrder'
+import { useUrlParams } from '~/hooks/useUrlParams'
 import SearchBar, { SearchBarWrap } from '~/shared/components/SearchBar'
 import Tabs, { Tab } from '~/shared/components/Tabs'
 import { useWalletAccount } from '~/shared/stores/wallet'
 import { COLORS, TABLET } from '~/shared/utils/styled'
-import { useCurrentChainFullName, useCurrentChainSymbolicName } from '~/utils/chains'
-import { Route as R, routeOptions } from '~/utils/routes'
-import { useUrlParams } from '~/hooks/useUrlParams'
 import { OrderDirection } from '~/types'
+import { useCurrentChainFullName, useCurrentChainKey } from '~/utils/chains'
+import { Route as R, routeOptions } from '~/utils/routes'
 
 const DEFAULT_ORDER_BY = 'peerCount'
 const DEFAULT_ORDER_DIRECTION = 'desc'
@@ -48,7 +48,7 @@ export function StreamsPage() {
 
     const account = useWalletAccount()
 
-    const chainName = useCurrentChainSymbolicName()
+    const chainName = useCurrentChainKey()
 
     useEffect(
         function changeToAllTabOnWalletLock() {

--- a/src/pages/StreamsPage.tsx
+++ b/src/pages/StreamsPage.tsx
@@ -48,7 +48,7 @@ export function StreamsPage() {
 
     const account = useWalletAccount()
 
-    const chainName = useCurrentChainKey()
+    const chainKey = useCurrentChainKey()
 
     useEffect(
         function changeToAllTabOnWalletLock() {
@@ -56,9 +56,9 @@ export function StreamsPage() {
                 return
             }
 
-            navigate(R.streams(routeOptions(chainName, { tab: StreamsTabOption.All })))
+            navigate(R.streams(routeOptions(chainKey, { tab: StreamsTabOption.All })))
         },
-        [account, navigate, chainName],
+        [account, navigate, chainKey],
     )
 
     const {
@@ -130,7 +130,7 @@ export function StreamsPage() {
                             fullWidthOnMobile
                             selection={tab}
                             onSelectionChange={(id) => {
-                                navigate(R.streams(routeOptions(chainName, { tab: id })))
+                                navigate(R.streams(routeOptions(chainKey, { tab: id })))
                             }}
                         >
                             <Tab id={StreamsTabOption.All}>All streams</Tab>
@@ -148,7 +148,7 @@ export function StreamsPage() {
                         </Tabs>
                     </FiltersWrap>
                     <CreateStreamButtonWrap>
-                        <Button as={Link} to={R.stream('new', routeOptions(chainName))}>
+                        <Button as={Link} to={R.stream('new', routeOptions(chainKey))}>
                             Create stream
                         </Button>
                     </CreateStreamButtonWrap>

--- a/src/shared/components/StreamSelectTable/index.tsx
+++ b/src/shared/components/StreamSelectTable/index.tsx
@@ -240,7 +240,7 @@ export const StreamSelectTable: FunctionComponent<Props> = ({
         }
     }, [selected])
 
-    const chainName = useCurrentChainKey()
+    const chainKey = useCurrentChainKey()
 
     return (
         <div>
@@ -267,7 +267,7 @@ export const StreamSelectTable: FunctionComponent<Props> = ({
                         return (
                             <TableRow key={s.id}>
                                 <StreamDetails
-                                    to={R.stream(s.id, routeOptions(chainName))}
+                                    to={R.stream(s.id, routeOptions(chainKey))}
                                 >
                                     <StreamId title={s.id}>
                                         {truncateStreamName(s.id, 40)}

--- a/src/shared/components/StreamSelectTable/index.tsx
+++ b/src/shared/components/StreamSelectTable/index.tsx
@@ -6,7 +6,7 @@ import { IndexerStream, TheGraphStream } from '~/services/streams'
 import Checkbox from '~/shared/components/Checkbox'
 import { COLORS, DESKTOP, MEDIUM, REGULAR, TABLET } from '~/shared/utils/styled'
 import { truncateStreamName } from '~/shared/utils/text'
-import { useCurrentChainSymbolicName } from '~/utils/chains'
+import { useCurrentChainKey } from '~/utils/chains'
 import { Route as R, routeOptions } from '~/utils/routes'
 
 const ROW_HEIGHT = 88
@@ -240,7 +240,7 @@ export const StreamSelectTable: FunctionComponent<Props> = ({
         }
     }, [selected])
 
-    const chainName = useCurrentChainSymbolicName()
+    const chainName = useCurrentChainKey()
 
     return (
         <div>

--- a/src/shared/components/Tile/index.tsx
+++ b/src/shared/components/Tile/index.tsx
@@ -193,12 +193,12 @@ function MarketplaceProductTile({
 }: MarketplaceProductTileProps) {
     const chainId = useCurrentChainId()
 
-    const chainName = useCurrentChainKey()
+    const chainKey = useCurrentChainKey()
 
     return (
         <Tile {...props}>
             <TileImageContainer>
-                <Link to={R.projectOverview(product.id, routeOptions(chainName))}>
+                <Link to={R.projectOverview(product.id, routeOptions(chainKey))}>
                     <TileImageContainer autoSize>
                         <TileThumbnail
                             src={
@@ -218,17 +218,17 @@ function MarketplaceProductTile({
                         right
                         linkTo={R.projectOverview(
                             product.id,
-                            routeOptions(chainName, undefined, 'stats'),
+                            routeOptions(chainKey, undefined, 'stats'),
                         )}
                     />
                 )}
                 {showEditButton && (
-                    <EditButton to={R.projectEdit(product.id, routeOptions(chainName))}>
+                    <EditButton to={R.projectEdit(product.id, routeOptions(chainKey))}>
                         <SvgIcon name={'pencilFull'} />
                     </EditButton>
                 )}
             </TileImageContainer>
-            <Link to={R.projectOverview(product.id, routeOptions(chainName))}>
+            <Link to={R.projectOverview(product.id, routeOptions(chainKey))}>
                 <Summary
                     name={
                         (product.metadata && product.metadata.name) || 'Untitled project'

--- a/src/shared/components/Tile/index.tsx
+++ b/src/shared/components/Tile/index.tsx
@@ -1,19 +1,18 @@
 import React from 'react'
-import styled, { css } from 'styled-components'
 import { Img } from 'react-image'
-import Logo from '~/shared/components/Logo'
-import Skeleton from '~/shared/components/Skeleton'
-import Rect from '~/shared/components/Rect'
+import styled, { css } from 'styled-components'
+import { getProjectImageUrl } from '~/getters'
+import { TheGraphProject } from '~/services/projects'
 import Link from '~/shared/components/Link'
+import Logo from '~/shared/components/Logo'
+import Rect from '~/shared/components/Rect'
+import Skeleton from '~/shared/components/Skeleton'
 import SvgIcon from '~/shared/components/SvgIcon'
 import { COLORS } from '~/shared/utils/styled'
-import { TheGraphProject } from '~/services/projects'
-import { getProjectImageUrl } from '~/getters'
-import { useCurrentChainId } from '~/utils/chains'
+import { useCurrentChainId, useCurrentChainKey } from '~/utils/chains'
 import { Route as R, routeOptions } from '~/utils/routes'
-import { useCurrentChainSymbolicName } from '~/utils/chains'
-import Summary from './Summary'
 import { DataUnionBadge, StreamStatsBadge } from './Badge'
+import Summary from './Summary'
 
 const Image = styled(Img)`
     img& {
@@ -194,7 +193,7 @@ function MarketplaceProductTile({
 }: MarketplaceProductTileProps) {
     const chainId = useCurrentChainId()
 
-    const chainName = useCurrentChainSymbolicName()
+    const chainName = useCurrentChainKey()
 
     return (
         <Tile {...props}>

--- a/src/stores/projectDraft.tsx
+++ b/src/stores/projectDraft.tsx
@@ -18,7 +18,7 @@ import { Operation } from '~/shared/toasts/TransactionListToast'
 import { ProjectType } from '~/shared/types'
 import { isProjectOwnedBy } from '~/utils'
 import { toBN } from '~/utils/bn'
-import { useCurrentChainSymbolicName } from '~/utils/chains'
+import { useCurrentChainKey } from '~/utils/chains'
 import { createDraftStore, getEmptyDraft } from '~/utils/draft'
 import networkPreflight from '~/utils/networkPreflight'
 import { Route as R, routeOptions } from '~/utils/routes'
@@ -278,7 +278,7 @@ export function usePersistProjectCallback() {
 
     const navigate = useNavigate()
 
-    const chainName = useCurrentChainSymbolicName()
+    const chainName = useCurrentChainKey()
 
     return useCallback(() => {
         persist({

--- a/src/stores/projectDraft.tsx
+++ b/src/stores/projectDraft.tsx
@@ -278,7 +278,7 @@ export function usePersistProjectCallback() {
 
     const navigate = useNavigate()
 
-    const chainName = useCurrentChainKey()
+    const chainKey = useCurrentChainKey()
 
     return useCallback(() => {
         persist({
@@ -287,7 +287,7 @@ export function usePersistProjectCallback() {
                     return
                 }
 
-                navigate(R.projects(routeOptions(chainName)))
+                navigate(R.projects(routeOptions(chainKey)))
             },
 
             onError(e) {
@@ -298,5 +298,5 @@ export function usePersistProjectCallback() {
                 console.warn('Failed to publish', e)
             },
         })
-    }, [persist, navigate, chainName])
+    }, [persist, navigate, chainKey])
 }

--- a/src/stores/streamDraft.tsx
+++ b/src/stores/streamDraft.tsx
@@ -22,11 +22,7 @@ import { Operation } from '~/shared/toasts/TransactionListToast'
 import getNativeTokenName from '~/shared/utils/nativeToken'
 import { requirePositiveBalance } from '~/shared/utils/requirePositiveBalance'
 import { Layer } from '~/utils/Layer'
-import {
-    getCurrentChainId,
-    useCurrentChainId,
-    useCurrentChainSymbolicName,
-} from '~/utils/chains'
+import { getCurrentChainId, useCurrentChainId, useCurrentChainKey } from '~/utils/chains'
 import { createDraftStore, getEmptyDraft } from '~/utils/draft'
 import {
     isMessagedObject,
@@ -597,7 +593,7 @@ const NewStreamLink = styled(Link)`
 
 function getOpenStreamLink(streamId: string) {
     return function OpenStreamLink() {
-        const chainName = useCurrentChainSymbolicName()
+        const chainName = useCurrentChainKey()
 
         const id: string = decodeURIComponent(
             useMatch(R.streamOverview(':id'))?.params['id'] || '',

--- a/src/stores/streamDraft.tsx
+++ b/src/stores/streamDraft.tsx
@@ -593,7 +593,7 @@ const NewStreamLink = styled(Link)`
 
 function getOpenStreamLink(streamId: string) {
     return function OpenStreamLink() {
-        const chainName = useCurrentChainKey()
+        const chainKey = useCurrentChainKey()
 
         const id: string = decodeURIComponent(
             useMatch(R.streamOverview(':id'))?.params['id'] || '',
@@ -604,7 +604,7 @@ function getOpenStreamLink(streamId: string) {
         }
 
         return (
-            <NewStreamLink to={R.streamOverview(streamId, routeOptions(chainName))}>
+            <NewStreamLink to={R.streamOverview(streamId, routeOptions(chainKey))}>
                 Open
             </NewStreamLink>
         )

--- a/src/utils/chains.ts
+++ b/src/utils/chains.ts
@@ -48,7 +48,7 @@ export function useCurrentChainId() {
 }
 
 export function useCurrentChainKey() {
-    return getSymbolicChainName(useCurrentChainId())
+    return getChainKey(useCurrentChainId())
 }
 
 /**
@@ -146,7 +146,7 @@ export function getChainConfig(chainIdOrSymbolicName: string | number): Chain {
     return getChainEntry(chainIdOrSymbolicName).config
 }
 
-export function getSymbolicChainName(chainId: number) {
+export function getChainKey(chainId: number) {
     return getChainEntry(chainId).symbolicName
 }
 

--- a/src/utils/chains.ts
+++ b/src/utils/chains.ts
@@ -2,8 +2,8 @@ import { Chain, config as configs } from '@streamr/config'
 import { produce } from 'immer'
 import { useMemo } from 'react'
 import { useSearchParams } from 'react-router-dom'
-import { ethereumNetworks } from '~/shared/utils/constants'
 import { defaultChainKey } from '~/consts'
+import { ethereumNetworks } from '~/shared/utils/constants'
 import {
     ChainConfigExtension,
     fallbackChainConfigExtension,
@@ -47,10 +47,7 @@ export function useCurrentChainId() {
     return useCurrentChain().id
 }
 
-/**
- * @todo rename to `useCurrentSymbolicChainName`
- */
-export function useCurrentChainSymbolicName() {
+export function useCurrentChainKey() {
     return getSymbolicChainName(useCurrentChainId())
 }
 

--- a/src/utils/chains.ts
+++ b/src/utils/chains.ts
@@ -61,7 +61,7 @@ export function useCurrentChainFullName() {
 interface ChainEntry {
     config: Chain
     configExtension: ChainConfigExtension
-    symbolicName: string
+    chainKey: string
 }
 
 const chainEntriesByIdOrName: Partial<Record<string | number, ChainEntry | null>> = {}
@@ -76,10 +76,10 @@ function getChainEntry(chainIdOrName: string | number) {
 
     if (typeof entry === 'undefined') {
         entry = (() => {
-            const source = Object.entries<Chain>(configs).find(([symbolicName, config]) =>
+            const source = Object.entries<Chain>(configs).find(([chainKey, config]) =>
                 typeof chainIdOrName === 'string'
                     ? getPreferredChainName(chainIdOrName) ===
-                      getPreferredChainName(symbolicName)
+                      getPreferredChainName(chainKey)
                     : chainIdOrName === config.id,
             )
 
@@ -87,12 +87,12 @@ function getChainEntry(chainIdOrName: string | number) {
                 return null
             }
 
-            const [rawSymbolicName, config] = source
+            const [rawChainKey, config] = source
 
-            const symbolicName = getPreferredChainName(rawSymbolicName)
+            const chainKey = getPreferredChainName(rawChainKey)
 
             const configExtension =
-                parsedChainConfigExtension[symbolicName] || fallbackChainConfigExtension
+                parsedChainConfigExtension[chainKey] || fallbackChainConfigExtension
 
             const { dockerHost } = configExtension
 
@@ -122,7 +122,7 @@ function getChainEntry(chainIdOrName: string | number) {
             })
 
             return {
-                symbolicName,
+                chainKey,
                 config: sanitizedConfig,
                 configExtension,
             }
@@ -142,12 +142,12 @@ function getChainEntry(chainIdOrName: string | number) {
     return entry
 }
 
-export function getChainConfig(chainIdOrSymbolicName: string | number): Chain {
-    return getChainEntry(chainIdOrSymbolicName).config
+export function getChainConfig(chainIdOrChainKey: string | number): Chain {
+    return getChainEntry(chainIdOrChainKey).config
 }
 
 export function getChainKey(chainId: number) {
-    return getChainEntry(chainId).symbolicName
+    return getChainEntry(chainId).chainKey
 }
 
 export function getChainConfigExtension(chainId: number) {

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -1,6 +1,6 @@
 import queryString from 'query-string'
 import { defaultChainKey } from '~/consts'
-import { getSymbolicChainName } from './chains'
+import { getChainKey } from './chains'
 
 interface RouteOptions {
     search?: Record<'chain', string> & Record<string, any>
@@ -15,7 +15,7 @@ export function routeOptions(
     return {
         search: {
             ...search,
-            chain: typeof chain === 'string' ? chain : getSymbolicChainName(chain),
+            chain: typeof chain === 'string' ? chain : getChainKey(chain),
         },
         hash,
     }


### PR DESCRIPTION
In this PR I get rid of all "symbolic" terminology in regards to chain configuration.

It's only about the renames.

In https://github.com/streamr-dev/network-contracts/pull/923 we used `ChainKey` to key the `Config` record. For the sake of consistency I now propagate this terminology across this repo, too.