### PR TITLE
Add chain "slug"; use proper chain key for Polygon Amoy (in local configs)

### DIFF
--- a/src/components/ChainSelector.tsx
+++ b/src/components/ChainSelector.tsx
@@ -9,7 +9,7 @@ import UnstyledNetworkIcon from '~/shared/components/NetworkIcon'
 import SvgIcon from '~/shared/components/SvgIcon'
 import { COLORS, LAPTOP } from '~/shared/utils/styled'
 import { StreamDraft } from '~/stores/streamDraft'
-import { getChainKey, useCurrentChain } from '~/utils/chains'
+import { getChainSlug, useCurrentChain } from '~/utils/chains'
 
 type MenuItemProps = {
     chain: Chain
@@ -45,14 +45,14 @@ const Menu = ({ chains, selectedChain, toggle }: MenuProps) => {
                         onClick={() => {
                             toggle(false)
 
-                            const chainKey = getChainKey(c.id)
+                            const slug = getChainSlug(c.id)
 
                             setSearchParams((prev) => {
                                 const { chain: _, ...rest } = Object.fromEntries(prev)
 
-                                return chainKey === defaultChainKey
+                                return slug === getChainSlug(defaultChainKey)
                                     ? rest
-                                    : { ...rest, chain: chainKey }
+                                    : { ...rest, chain: slug }
                             })
                         }}
                     />

--- a/src/config/chains.toml
+++ b/src/config/chains.toml
@@ -22,6 +22,7 @@ name = "streamr-dev/dataunion"
 [polygonAmoy]
 dataUnionJoinServerUrl = "https://join.dataunions.org/"
 marketplaceChains = ['polygonAmoy']
+slug = 'amoy'
 
 [[polygonAmoy.storageNodes]]
 name = "Streamr Germany"

--- a/src/config/chains.toml
+++ b/src/config/chains.toml
@@ -19,15 +19,15 @@ address = "0xde1112f631486CfC759A50196853011528bC5FA0"
 chainId = 31337
 name = "streamr-dev/dataunion"
 
-[amoy]
+[polygonAmoy]
 dataUnionJoinServerUrl = "https://join.dataunions.org/"
-marketplaceChains = ['amoy']
+marketplaceChains = ['polygonAmoy']
 
-[[amoy.storageNodes]]
+[[polygonAmoy.storageNodes]]
 name = "Streamr Germany"
 address = "0x31546eEA76F2B2b3C5cC06B1c93601dc35c9D916"
 
-[[amoy.dataunionGraphNames]]
+[[polygonAmoy.dataunionGraphNames]]
 chainId = 80002
 name = "samt1803/dataunion-subgraphs"
 

--- a/src/config/environments.toml
+++ b/src/config/environments.toml
@@ -1,12 +1,12 @@
 [development]
-availableChains = ['dev2', 'polygon', 'amoy']
+availableChains = ['dev2', 'polygon', 'polygonAmoy']
 platformOriginUrl = ""
 streamrUrl = ""
 
-[amoy]
-availableChains = ['amoy', 'polygon']
+[polygonAmoy]
+availableChains = ['polygonAmoy', 'polygon']
 platformOriginUrl = "https://staging.streamr.network"
 streamrUrl = "https://staging.streamr.network"
 
 [production]
-availableChains = ['polygon', 'amoy']
+availableChains = ['polygon', 'polygonAmoy']

--- a/src/utils/chainConfigExtension.ts
+++ b/src/utils/chainConfigExtension.ts
@@ -32,6 +32,7 @@ const ChainConfigExtension = z.object({
         }),
     marketplaceChains: z.array(z.string()).optional().default([]),
     networkSubgraphUrl: z.string().optional(),
+    slug: z.string().optional(),
     sponsorshipPaymentToken: z.string().optional().default('DATA'),
     storageNodes: z
         .array(

--- a/src/utils/chains.ts
+++ b/src/utils/chains.ts
@@ -159,6 +159,12 @@ export function getChainConfigExtension(chainId: number): ChainConfigExtension {
     return getChainEntry(getChainKey(chainId)).configExtension
 }
 
+export function getChainSlug(chainIdOrChainKey: ChainKey | number): string {
+    const chainEntry = getChainEntry(getChainKey(chainIdOrChainKey))
+
+    return chainEntry.configExtension.slug || chainEntry.chainKey
+}
+
 /**
  * Checks if a given string is a `ChainKey`.
  * @param candidate Any string.

--- a/src/utils/chains.ts
+++ b/src/utils/chains.ts
@@ -104,11 +104,11 @@ interface ChainEntry {
     chainKey: ChainKey
 }
 
-const chainEntriesByIdOrName: Partial<Record<ChainKey, ChainEntry | null>> = {}
+const chainKeyToChainEntryMap: Partial<Record<ChainKey, ChainEntry | null>> = {}
 
 function getChainEntry(chainKey: ChainKey): ChainEntry {
-    if (chainEntriesByIdOrName[chainKey]) {
-        return chainEntriesByIdOrName[chainKey]
+    if (chainKeyToChainEntryMap[chainKey]) {
+        return chainKeyToChainEntryMap[chainKey]
     }
 
     const config: Chain = configs[chainKey]
@@ -146,7 +146,7 @@ function getChainEntry(chainKey: ChainKey): ChainEntry {
         configExtension,
     }
 
-    chainEntriesByIdOrName[chainKey] = entry
+    chainKeyToChainEntryMap[chainKey] = entry
 
     return entry
 }

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -1,5 +1,7 @@
+import { ChainKey } from '@streamr/config'
 import queryString from 'query-string'
 import { defaultChainKey } from '~/consts'
+import { parsedChainConfigExtension } from '~/utils/chainConfigExtension'
 import { getChainKey } from './chains'
 
 interface RouteOptions {
@@ -8,14 +10,19 @@ interface RouteOptions {
 }
 
 export function routeOptions(
-    chain: string | number,
+    chainIdOrChainKey: ChainKey | number,
     search: Record<string, any> = {},
     hash = '',
 ): RouteOptions {
+    const chain =
+        typeof chainIdOrChainKey === 'number'
+            ? getChainKey(chainIdOrChainKey)
+            : parsedChainConfigExtension[chainIdOrChainKey]?.slug || chainIdOrChainKey
+
     return {
         search: {
             ...search,
-            chain: typeof chain === 'string' ? chain : getChainKey(chain),
+            chain,
         },
         hash,
     }

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -1,8 +1,7 @@
 import { ChainKey } from '@streamr/config'
 import queryString from 'query-string'
 import { defaultChainKey } from '~/consts'
-import { parsedChainConfigExtension } from '~/utils/chainConfigExtension'
-import { getChainKey } from './chains'
+import { getChainSlug } from './chains'
 
 interface RouteOptions {
     search?: Record<'chain', string> & Record<string, any>
@@ -14,15 +13,10 @@ export function routeOptions(
     search: Record<string, any> = {},
     hash = '',
 ): RouteOptions {
-    const chain =
-        typeof chainIdOrChainKey === 'number'
-            ? getChainKey(chainIdOrChainKey)
-            : parsedChainConfigExtension[chainIdOrChainKey]?.slug || chainIdOrChainKey
-
     return {
         search: {
             ...search,
-            chain,
+            chain: getChainSlug(chainIdOrChainKey),
         },
         hash,
     }


### PR DESCRIPTION
In this PR I eliminate the special case where we'd use `amoy` as a chain key (fake) for what should've been `polygonAmoy` (the actual chain key for Polygon Amoy testnet).

I do so in the following way:
1. Add `slug` to config extension (to `polygonAmoy`'s config) – see `chains.yml`.
2. Use the slug in `getChainKey` to map it to the actual chain key, and in `routeOptions` for proper search query output.

This way any chain (new or existing) can have a short preferred identifier to be used in urls. All for the sake of making adding new chains easier.

In addition, the `getPreferredChainName` got renamed to `getChainKey` and refactored. It now always returns a `ChainKey`. It defaults to `defaultChainKey` if it fails to identify the candidate, and warns about such situation via `console.warn`.
