### PR TITLE
Chain's display name done right

### DIFF
--- a/src/components/ChainSelector.tsx
+++ b/src/components/ChainSelector.tsx
@@ -9,18 +9,18 @@ import UnstyledNetworkIcon from '~/shared/components/NetworkIcon'
 import SvgIcon from '~/shared/components/SvgIcon'
 import { COLORS, LAPTOP } from '~/shared/utils/styled'
 import { StreamDraft } from '~/stores/streamDraft'
-import { getChainSlug, useCurrentChain } from '~/utils/chains'
+import { getChainDisplayName, getChainSlug, useCurrentChain } from '~/utils/chains'
 
 type MenuItemProps = {
-    chain: Chain
+    chainId: number
     isSelected: boolean
     onClick: () => void
 }
 
-const MenuItem = ({ chain, isSelected, onClick }: MenuItemProps) => (
+const MenuItem = ({ chainId, isSelected, onClick }: MenuItemProps) => (
     <MenuItemContainer onClick={onClick}>
-        <NetworkIcon chainId={chain.id} />
-        <div>{chain.name}</div>
+        <NetworkIcon chainId={chainId} />
+        <div>{getChainDisplayName(chainId)}</div>
         {isSelected ? <SvgIcon name="tick" /> : <div />}
     </MenuItemContainer>
 )
@@ -40,7 +40,7 @@ const Menu = ({ chains, selectedChain, toggle }: MenuProps) => {
                 {chains.map((c) => (
                     <MenuItem
                         key={c.id}
-                        chain={c}
+                        chainId={c.id}
                         isSelected={c.id === selectedChain.id}
                         onClick={() => {
                             toggle(false)
@@ -67,7 +67,7 @@ interface Props {
 }
 
 export const ChainSelector = ({ menuAlignment = 'left', ...props }: Props) => {
-    const availableChains = getEnvironmentConfig().availableChains
+    const { availableChains } = getEnvironmentConfig()
 
     const selectedChain = useCurrentChain()
 
@@ -89,7 +89,7 @@ export const ChainSelector = ({ menuAlignment = 'left', ...props }: Props) => {
             {(toggle, isOpen) => (
                 <Toggle $isOpen={isOpen} onClick={() => toggle((v) => !v)}>
                     <NetworkIcon chainId={selectedChain.id} />
-                    <div>{selectedChain.name}</div>
+                    <div>{getChainDisplayName(selectedChain.id)}</div>
                     <Caret name="caretUp" $isOpen={isOpen} />
                 </Toggle>
             )}

--- a/src/components/SalePointSelector/SalePointOption.tsx
+++ b/src/components/SalePointSelector/SalePointOption.tsx
@@ -1,17 +1,16 @@
+import { produce } from 'immer'
 import React, { ComponentProps, ReactNode, useEffect, useRef, useState } from 'react'
 import styled, { css } from 'styled-components'
 import { z } from 'zod'
-import { produce } from 'immer'
-import SvgIcon from '~/shared/components/SvgIcon'
-import { SalePoint } from '~/shared/types'
-import { COLORS } from '~/shared/utils/styled'
+import { getDataUnion, getDataUnionsOwnedByInChain } from '~/getters/du'
+import { SelectField2 } from '~/marketplace/components/SelectField2'
 import { Tick as PrestyledTick } from '~/shared/components/Checkbox'
 import NetworkIcon from '~/shared/components/NetworkIcon'
-import { formatChainName } from '~/utils'
+import SvgIcon from '~/shared/components/SvgIcon'
 import { useWalletAccount } from '~/shared/stores/wallet'
-import { SelectField2 } from '~/marketplace/components/SelectField2'
-import { getDataUnion, getDataUnionsOwnedByInChain } from '~/getters/du'
-import { getChainConfig } from '~/utils/chains'
+import { SalePoint } from '~/shared/types'
+import { COLORS } from '~/shared/utils/styled'
+import { getChainDisplayName } from '~/utils/chains'
 import { Root as SalePointTokenSelectorRoot } from './SalePointTokenSelector'
 
 export interface OptionProps {
@@ -31,10 +30,6 @@ export default function SalePointOption({
     multiSelect = false,
 }: SalePointOptionProps) {
     const { chainId, enabled, readOnly } = salePoint
-
-    const chain = getChainConfig(chainId)
-
-    const formattedChainName = formatChainName(chain.name)
 
     return (
         <DropdownWrap $open={enabled}>
@@ -56,7 +51,7 @@ export default function SalePointOption({
                     <RadioCircle $checked={enabled} $disabled={readOnly} />
                 )}
                 <ChainIcon chainId={chainId} />
-                <ToggleText>{formattedChainName}</ToggleText>
+                <ToggleText>{getChainDisplayName(chainId)}</ToggleText>
                 {multiSelect && <PlusSymbol />}
             </DropdownToggle>
             <DropdownOuter>

--- a/src/config/chains.toml
+++ b/src/config/chains.toml
@@ -1,11 +1,28 @@
+[ethereum]
+displayName = "Ethereum Mainnet"
+
+[binance]
+coingeckoNetworkId = "binance-smart-chain"
+displayName = "BNB Smart Chain"
+
+[gnosis]
+coingeckoNetworkId = "xdai"
+displayName = "Gnosis"
+
 [dev0]
+coingeckoNetworkId = "ethereum"
 dockerHost = "localhost"
+displayName = "Dev0"
 
 [dev1]
+coingeckoNetworkId = "ethereum"
 dockerHost = "localhost"
+displayName = "Dev1"
 
 [dev2]
+coingeckoNetworkId = "ethereum"
 dataUnionJoinServerUrl = ":5555"
+displayName = "Dev2"
 dockerHost = "localhost"
 marketplaceChains = ['dev2']
 networkSubgraphUrl = ":8800/subgraphs/name/streamr-dev/network-subgraphs"
@@ -21,6 +38,7 @@ name = "streamr-dev/dataunion"
 
 [polygonAmoy]
 dataUnionJoinServerUrl = "https://join.dataunions.org/"
+displayName = "Amoy"
 marketplaceChains = ['polygonAmoy']
 slug = 'amoy'
 

--- a/src/modals/AccessPeriodModal.tsx
+++ b/src/modals/AccessPeriodModal.tsx
@@ -10,9 +10,8 @@ import Text from '~/shared/components/Ui/Text'
 import useIsMounted from '~/shared/hooks/useIsMounted'
 import { COLORS, LIGHT, MEDIUM } from '~/shared/utils/styled'
 import { TimeUnit, timeUnits } from '~/shared/utils/timeUnit'
-import { formatChainName } from '~/utils'
 import { toFloat } from '~/utils/bn'
-import { getChainConfig } from '~/utils/chains'
+import { getChainDisplayName } from '~/utils/chains'
 import { RejectionReason } from '~/utils/exceptions'
 import { convertPrice } from '~/utils/price'
 import ProjectModal, { Actions } from './ProjectModal'
@@ -202,8 +201,6 @@ export default function AccessPeriodModal({
         setSelectedUnit(unit)
     }, [unit])
 
-    const chainName = formatChainName(getChainConfig(chainId).name)
-
     const total = ((a: bigint) => (a > 0n ? a : 0n))(
         convertPrice(pricePerSecond, [length, selectedUnit]),
     )
@@ -289,7 +286,7 @@ export default function AccessPeriodModal({
                 <DetailsContainer>
                     <Chain>
                         <ChainIcon chainId={chainId} />
-                        <ChainName>{chainName}</ChainName>
+                        <ChainName>{getChainDisplayName(chainId)}</ChainName>
                     </Chain>
                     <AmountBox>
                         <AmountBar>

--- a/src/modals/ChainSelectorModal.tsx
+++ b/src/modals/ChainSelectorModal.tsx
@@ -6,9 +6,8 @@ import NetworkIcon from '~/shared/components/NetworkIcon'
 import useIsMounted from '~/shared/hooks/useIsMounted'
 import { getUsdRate } from '~/shared/utils/coingecko'
 import { MEDIUM } from '~/shared/utils/styled'
-import { formatChainName } from '~/utils'
 import { getBalance } from '~/utils/balance'
-import { getChainConfig } from '~/utils/chains'
+import { getChainDisplayName } from '~/utils/chains'
 import { RejectionReason } from '~/utils/exceptions'
 import networkPreflight from '~/utils/networkPreflight'
 import { getTokenInfo } from '~/utils/tokens'
@@ -241,9 +240,7 @@ export default function ChainSelectorModal({
                                     }
                                 >
                                     <ChainIcon chainId={chainId} />
-                                    <ChainName>
-                                        {formatChainName(getChainConfig(chainId).name)}
-                                    </ChainName>
+                                    <ChainName>{getChainDisplayName(chainId)}</ChainName>
                                     <Radio $selected={selectedChainId === chainId} />
                                 </Item>
                             </li>

--- a/src/modals/SwitchNetworkModal.tsx
+++ b/src/modals/SwitchNetworkModal.tsx
@@ -2,28 +2,26 @@ import React from 'react'
 import styled from 'styled-components'
 import { Buttons } from '~/components/Buttons'
 import PngIcon from '~/shared/components/PngIcon'
-import { getChainDisplayName, getChainKey } from '~/utils/chains'
+import { getChainDisplayName, getChainKey, isKnownChainId } from '~/utils/chains'
 import { RejectionReason } from '~/utils/exceptions'
 import { Footer } from './BaseModal'
 import Modal, { ModalProps } from './Modal'
 
 interface Props extends Pick<ModalProps, 'onReject' | 'darkBackdrop'> {
-    expectedNetwork: number | string
-    actualNetwork: number | string
+    expectedChainId: number
+    actualChainId: number
     onResolve?: () => void
 }
 
-function getChainName(chainId: number | string) {
-    try {
-        return getChainDisplayName(getChainKey(chainId, { failOnNotFound: true }))
-    } catch (_) {
-        return `#${chainId}`
-    }
+function getChainName(chainId: number) {
+    return isKnownChainId(chainId)
+        ? getChainDisplayName(getChainKey(chainId))
+        : `#${chainId}`
 }
 
 export default function SwitchNetworkModal({
-    expectedNetwork,
-    actualNetwork,
+    expectedChainId,
+    actualChainId,
     onReject,
     onResolve,
     ...props
@@ -47,9 +45,9 @@ export default function SwitchNetworkModal({
                     <PngIcon name="wallet" alt="Switch network" />
                 </IconWrap>
                 <P>
-                    Please switch to the <em>{getChainName(expectedNetwork)}</em> network
+                    Please switch to the <em>{getChainName(expectedChainId)}</em> network
                     in your Ethereum wallet. It&apos;s currently in{' '}
-                    <em>{getChainName(actualNetwork)}</em>
+                    <em>{getChainName(actualChainId)}</em>
                     &nbsp;network.
                 </P>
             </Content>

--- a/src/modals/SwitchNetworkModal.tsx
+++ b/src/modals/SwitchNetworkModal.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { Buttons } from '~/components/Buttons'
 import PngIcon from '~/shared/components/PngIcon'
-import { getChainConfig } from '~/utils/chains'
+import { getChainDisplayName, getChainKey } from '~/utils/chains'
 import { RejectionReason } from '~/utils/exceptions'
 import { Footer } from './BaseModal'
 import Modal, { ModalProps } from './Modal'
@@ -15,7 +15,7 @@ interface Props extends Pick<ModalProps, 'onReject' | 'darkBackdrop'> {
 
 function getChainName(chainId: number | string) {
     try {
-        return getChainConfig(chainId).name
+        return getChainDisplayName(getChainKey(chainId, { failOnNotFound: true }))
     } catch (_) {
         return `#${chainId}`
     }

--- a/src/pages/ProjectPage/AccessManifest.tsx
+++ b/src/pages/ProjectPage/AccessManifest.tsx
@@ -13,8 +13,11 @@ import { ProjectType, SalePoint } from '~/shared/types'
 import { REGULAR, TABLET } from '~/shared/utils/styled'
 import { timeUnits } from '~/shared/utils/timeUnit'
 import { useIsAccessibleByCurrentWallet } from '~/stores/projectDraft'
-import { formatChainName } from '~/utils'
-import { getChainConfig, useCurrentChainId, useCurrentChainKey } from '~/utils/chains'
+import {
+    getChainDisplayName,
+    useCurrentChainId,
+    useCurrentChainKey,
+} from '~/utils/chains'
 import { Route as R, routeOptions } from '~/utils/routes'
 import { errorToast } from '~/utils/toast'
 
@@ -65,7 +68,7 @@ export function AccessManifest({
                             timeUnit={timeUnits.hour}
                         />
                     </strong>{' '}
-                    on <strong>{formatChainName(getChainConfig(chainId).name)}</strong>
+                    on <strong>{getChainDisplayName(chainId)}</strong>
                     {count > 0 && (
                         <>
                             {' '}

--- a/src/pages/ProjectPage/GetAccess.tsx
+++ b/src/pages/ProjectPage/GetAccess.tsx
@@ -12,8 +12,7 @@ import {
 import { ProjectType, SalePoint } from '~/shared/types'
 import { MEDIUM } from '~/shared/utils/styled'
 import { timeUnits } from '~/shared/utils/timeUnit'
-import { formatChainName } from '~/utils'
-import { getChainConfig, useCurrentChainId } from '~/utils/chains'
+import { getChainDisplayName, useCurrentChainId } from '~/utils/chains'
 import { errorToast } from '~/utils/toast'
 
 const GetAccessContainer = styled.div`
@@ -90,7 +89,7 @@ export default function GetAccess({
                             timeUnit={timeUnits.hour}
                         />
                     </strong>{' '}
-                    on <strong>{formatChainName(getChainConfig(chainId).name)}</strong>
+                    on <strong>{getChainDisplayName(chainId)}</strong>
                     {count > 0 && (
                         <>
                             and on {count} other chain{count > 1 && 's'}

--- a/src/shared/utils/constants.ts
+++ b/src/shared/utils/constants.ts
@@ -19,18 +19,4 @@ export const paymentCurrencies = {
     NATIVE: 'NATIVE',
 }
 
-export const ethereumNetworks = {
-    '1': 'Ethereum Mainnet',
-    '3': 'Ropsten',
-    '4': 'Rinkeby',
-    '5': 'Görli',
-    '42': 'Kovan',
-    '100': 'Gnosis',
-    '137': 'Polygon',
-    '8995': 'Dev0',
-    '8997': 'Dev1',
-    '31337': 'Dev2',
-    '80002': 'Amoy',
-}
-
 export const maxFileSizeForImageUpload = 5242880

--- a/src/shared/utils/tokenAssets.ts
+++ b/src/shared/utils/tokenAssets.ts
@@ -1,4 +1,4 @@
-import { getChainConfig } from '~/utils/chains'
+import { getCoingecoNetworkId } from '~/utils/chains'
 
 const BASE_URL = 'https://streamr-public.s3.amazonaws.com/truswallet-assets/blockchains'
 
@@ -6,21 +6,11 @@ export const getTokenLogoUrl = (
     tokenContractAddress: string,
     chainId: number,
 ): string => {
-    const network = (() => {
-        switch (chainId) {
-            case 100:
-                return 'xdai'
-            case 8995:
-            case 8996:
-                return 'ethereum'
-            default:
-                return getChainConfig(chainId).name
-        }
-    })()
+    const networkId = getCoingecoNetworkId(chainId)
 
     /**
      * For more details see:
      * https://api.coingecko.com/api/v3/asset_platforms
      */
-    return `${BASE_URL}/${network}/assets/${tokenContractAddress}/logo.png`
+    return `${BASE_URL}/${networkId}/assets/${tokenContractAddress}/logo.png`
 }

--- a/src/shared/utils/tokenAssets.ts
+++ b/src/shared/utils/tokenAssets.ts
@@ -1,4 +1,4 @@
-import { getCoingecoNetworkId } from '~/utils/chains'
+import { getCoingeckoNetworkId } from '~/utils/chains'
 
 const BASE_URL = 'https://streamr-public.s3.amazonaws.com/truswallet-assets/blockchains'
 
@@ -6,7 +6,7 @@ export const getTokenLogoUrl = (
     tokenContractAddress: string,
     chainId: number,
 ): string => {
-    const networkId = getCoingecoNetworkId(chainId)
+    const networkId = getCoingeckoNetworkId(chainId)
 
     /**
      * For more details see:

--- a/src/types/projects.ts
+++ b/src/types/projects.ts
@@ -3,16 +3,23 @@ import { z } from 'zod'
 import { address0 } from '~/consts'
 import { ProjectType, SalePoint } from '~/shared/types'
 import { timeUnits } from '~/shared/utils/timeUnit'
-import { formatChainName } from '~/utils'
-import { getCurrentChain } from '~/utils/chains'
+import {
+    getChainDisplayName,
+    getChainKey,
+    getCurrentChain,
+    isChainKey,
+} from '~/utils/chains'
 import { getContractAddress } from '~/utils/contracts'
 
-function getFormattedChainNameFromContext({ path: [, chainName] }: z.RefinementCtx) {
-    if (typeof chainName !== 'string' || !chainName) {
-        return ''
-    }
+function getFormattedChainNameFromContext({ path: [, chainKey] }: z.RefinementCtx) {
+    const chainName =
+        typeof chainKey === 'number'
+            ? `#${chainKey}`
+            : isChainKey(chainKey)
+            ? getChainDisplayName(chainKey)
+            : `"${chainKey}"`
 
-    return `for ${formatChainName(chainName)} network`
+    return `for ${chainName} network`
 }
 
 export const SalePointsPayload = z.record(
@@ -192,10 +199,10 @@ export const OpenDataPayload = z.object({
             .transform((v) => v || undefined),
     }),
     salePoints: SalePointsPayload.transform(() => {
-        const { name: chainName, id: chainId } = getCurrentChain()
+        const { id: chainId } = getCurrentChain()
 
         return {
-            [chainName]: {
+            [getChainKey(chainId)]: {
                 beneficiaryAddress: address0,
                 chainId,
                 enabled: true,

--- a/src/utils/chainConfigExtension.ts
+++ b/src/utils/chainConfigExtension.ts
@@ -5,6 +5,7 @@ import config from '~/config/chains.toml'
 import formatConfigUrl from '~/utils/formatConfigUrl'
 
 const ChainConfigExtension = z.object({
+    coingeckoNetworkId: z.string().optional(),
     dataUnionJoinServerUrl: z.string().optional(),
     dataunionGraphNames: z
         .array(
@@ -15,6 +16,7 @@ const ChainConfigExtension = z.object({
         )
         .optional()
         .default([]),
+    displayName: z.string().optional(),
     dockerHost: z.string().optional(),
     ipfs: z
         .object({

--- a/src/utils/chains.test.ts
+++ b/src/utils/chains.test.ts
@@ -1,0 +1,74 @@
+import { config } from '@streamr/config'
+import { defaultChainKey } from '../consts'
+import { parsedChainConfigExtension } from './chainConfigExtension'
+import {
+    getChainDisplayName,
+    getChainKey,
+    getMarketplaceChainConfigs,
+    isChainKey,
+} from './chains'
+
+describe('getChainKey', () => {
+    it('defaults to the default chain key', () => {
+        expect(getChainKey('whatever')).toEqual(defaultChainKey)
+
+        expect(getChainKey(0)).toEqual(defaultChainKey)
+    })
+
+    it('extracts chain key by slug', () => {
+        expect(getChainKey('amoy')).toEqual('polygonAmoy')
+    })
+
+    it('is case insensitive', () => {
+        expect(getChainKey('AMOY')).toEqual('polygonAmoy')
+
+        expect(getChainKey('POlyGON')).toEqual('polygon')
+
+        expect(getChainKey('polygonamoy')).toEqual('polygonAmoy')
+    })
+
+    it('resolves a number to a chain key', () => {
+        expect(getChainKey(137)).toEqual('polygon')
+
+        expect(getChainKey(100)).toEqual('gnosis')
+    })
+})
+
+describe('isChainKey', () => {
+    it('correctly identifies chain keys', () => {
+        expect(isChainKey('whatever')).toBe(false)
+
+        expect(isChainKey('polygon')).toBe(true)
+
+        expect(isChainKey('gnosis')).toBe(true)
+    })
+})
+
+describe('getChainDisplayName', () => {
+    it('used custom naming for chains that we provide it for', () => {
+        // Local config extension provides a custom value
+        expect(parsedChainConfigExtension['polygonAmoy']?.displayName).toEqual('Amoy')
+
+        // Config provides a diffrent value
+        expect(config.polygonAmoy.name).not.toEqual('Amoy')
+
+        // Ultimately local name counts
+        expect(getChainDisplayName('polygonAmoy')).toEqual('Amoy')
+    })
+})
+
+describe('getMarketplaceChainConfigs', () => {
+    it('gives a list of configs for given keys', () => {
+        const [config0, config1, config2] = getMarketplaceChainConfigs('polygon')
+
+        expect(config0.id).toEqual(config.gnosis.id)
+
+        expect(config1.id).toEqual(config.polygon.id)
+
+        expect(config2).toBeUndefined()
+    })
+
+    it('gives an empty list of configs if there are no marketplace chain keys provided', () => {
+        expect(getMarketplaceChainConfigs('ethereum').length).toEqual(0)
+    })
+})

--- a/src/utils/chains.ts
+++ b/src/utils/chains.ts
@@ -198,7 +198,7 @@ export function getMarketplaceChainConfigs(
     return result
 }
 
-export function getCoingecoNetworkId(chainIdOrChainKey: ChainKey | number) {
+export function getCoingeckoNetworkId(chainIdOrChainKey: ChainKey | number) {
     const { config, configExtension } = getChainEntry(getChainKey(chainIdOrChainKey))
 
     return configExtension.coingeckoNetworkId || config.name

--- a/src/utils/chains.ts
+++ b/src/utils/chains.ts
@@ -12,25 +12,14 @@ import formatConfigUrl from './formatConfigUrl'
 
 const lowerCasedChainKeyToChainKeyMap: Record<string, ChainKey | null | undefined> = {}
 
-interface GetChainKeyOptions {
-    failOnNotFound?: boolean
-}
-
 /**
  * @param candidate Chain key or chain slug (from config extension) or chain number. Defaults
  * to the default chain key (currently 'polygon').
  */
-export function getChainKey(
-    candidate: string | number,
-    { failOnNotFound = false }: GetChainKeyOptions = {},
-): ChainKey {
+export function getChainKey(candidate: string | number): ChainKey {
     const key = typeof candidate === 'number' ? candidate : candidate.toLowerCase()
 
     if (lowerCasedChainKeyToChainKeyMap[key] === null) {
-        if (failOnNotFound) {
-            throw new Error('ChainKey not found')
-        }
-
         return defaultChainKey
     }
 
@@ -73,10 +62,6 @@ export function getChainKey(
     )
 
     lowerCasedChainKeyToChainKeyMap[key] = null
-
-    if (failOnNotFound) {
-        throw new Error('ChainKey not found')
-    }
 
     return defaultChainKey
 }
@@ -184,6 +169,10 @@ export function getChainSlug(chainIdOrChainKey: ChainKey | number): string {
  */
 export function isChainKey(candidate: string): candidate is ChainKey {
     return Object.prototype.hasOwnProperty.call(configs, candidate)
+}
+
+export function isKnownChainId(candidate: number): boolean {
+    return Object.entries(configs).some(([, { id }]) => id === candidate)
 }
 
 export function getChainDisplayName(chainIdOrChainKey: ChainKey | number): string {

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -131,27 +131,6 @@ export async function sleep(millis: number) {
 }
 
 /**
- * Turns `abc`, `ABC`, `aBc` into `Abc`.
- */
-function titleize(value: string): string {
-    return value.toLowerCase().replace(/\w/, (firstLetter) => firstLetter.toUpperCase())
-}
-
-/**
- * Converts a string into a good-looking display-ready chain name.
- */
-export function formatChainName(chainName: string): string {
-    switch (chainName.toLowerCase()) {
-        case 'xdai':
-            return formatChainName('gnosis')
-        case 'bsc':
-            return 'Binance Smart Chain'
-        default:
-            return titleize(chainName)
-    }
-}
-
-/**
  * Takes the user back in history, but only if they've already navigated
  * somewhere within the app.
  * @param options.onBeforeNavigate Optional callback triggered right before

--- a/src/utils/networkPreflight.ts
+++ b/src/utils/networkPreflight.ts
@@ -2,7 +2,7 @@ import { toaster } from 'toasterhea'
 import SwitchNetworkModal from '~/modals/SwitchNetworkModal'
 import { getWalletProvider } from '~/shared/stores/wallet'
 import { Layer } from '~/utils/Layer'
-import { getChainConfig } from '~/utils/chains'
+import { getChainConfig, getChainDisplayName } from '~/utils/chains'
 import getChainId from '~/utils/web3/getChainId'
 
 /**
@@ -45,7 +45,7 @@ export default async function networkPreflight(expectedChainId: number) {
             params: [
                 {
                     chainId: `0x${chainConfig.id.toString(16)}`,
-                    chainName: chainConfig.name,
+                    chainName: getChainDisplayName(chainConfig.id),
                     rpcUrls: chainConfig.rpcEndpoints.map(({ url }) => url),
                     nativeCurrency: chainConfig.nativeCurrency,
                     blockExplorerUrls: [chainConfig.blockExplorerUrl].filter(

--- a/src/utils/networkPreflight.ts
+++ b/src/utils/networkPreflight.ts
@@ -14,15 +14,15 @@ export default async function networkPreflight(expectedChainId: number) {
     const provider = await getWalletProvider()
 
     try {
-        const currentChainId = await getChainId()
+        const actualChainId = await getChainId()
 
-        if (currentChainId === expectedChainId) {
+        if (actualChainId === expectedChainId) {
             return false
         }
 
         await toaster(SwitchNetworkModal, Layer.Modal).pop({
-            expectedNetwork: expectedChainId,
-            actualNetwork: currentChainId,
+            expectedChainId,
+            actualChainId,
         })
 
         await provider.request({


### PR DESCRIPTION
We now have the `getChainDisplayName` that uses local chain config extensions (see `chains.yml`) for any local per-chain human readable name customisation.

We used to have `formatChainName`, `chain.name` (modded in `chains.ts`), and the `ethereumNetworks` id-to-name map. Now it's all packed nicely into the new utility function.

This should help us a bunch.

I've also identified that we've been using human readable names to key sale points in the "project" part of the hub. Not ideal, to say the least. Switched it up to the chain key.