### PR TITLE
feat: [FRONT-2099] support arbitrary hex strings for granting pubsub permissions on Hub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Start Streamr Docker Stack
         uses: streamr-dev/streamr-docker-dev-action@v1.0.1
         with:
-          services-to-start: "cassandra mysql nginx entry-point broker-node-storage-1 broker-node-no-storage-1 broker-node-no-storage-2 dev-chain-fast postgres-fastchain"
+          services-to-start: "cassandra mysql entry-point broker-node-storage-1 broker-node-no-storage-1 broker-node-no-storage-2 dev-chain-fast postgres-fastchain"
       - name: Run Jest Tests
         run: echo $CHUNKS | jq '.[${{ matrix.chunk }}] | .[] | @text' | xargs npx jest --verbose --useStderr --forceExit --coverage=false --logHeapUsage --runInBand
         env:

--- a/src/modals/NewStreamPermissionsModal.tsx
+++ b/src/modals/NewStreamPermissionsModal.tsx
@@ -78,10 +78,6 @@ export default function NewStreamPermissionsModal({
                     return void setError('Invalid key - must be a hex string')
                 }
 
-                if (permissionBits === 0) {
-                    return void setError('Please select some of the permissions')
-                }
-
                 if (!ethereumAddressRegex.test(normalizedPublicKey) && (
                     matchBits(Bits[StreamPermission.GRANT], permissionBits) ||
                     matchBits(Bits[StreamPermission.DELETE], permissionBits) ||
@@ -107,7 +103,7 @@ export default function NewStreamPermissionsModal({
 
                 onResolve?.(result)
             }}
-            canSubmit={!!publicKey}
+            canSubmit={!!publicKey && permissionBits !== 0}
             submitLabel="Authorize Public Key"
             cancelLabel={cancelLabel}
         >

--- a/src/modals/NewStreamPermissionsModal.tsx
+++ b/src/modals/NewStreamPermissionsModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import styled from 'styled-components'
+import { StreamPermission } from '@streamr/sdk'
 import PermissionEditor from '~/pages/AbstractStreamEditPage/AccessControlSection/PermissionEditor'
 import { Bits, matchBits, setBits, unsetBits } from '~/parsers/StreamParser'
 import UnstyledErrors, { MarketplaceTheme } from '~/shared/components/Ui/Errors'
@@ -8,7 +9,6 @@ import Text from '~/shared/components/Ui/Text'
 import { COLORS, TABLET } from '~/shared/utils/styled'
 import { RejectionReason, isMessagedObject } from '~/utils/exceptions'
 import FormModal, { FormModalProps } from './FormModal'
-import { StreamPermission } from '@streamr/sdk'
 
 const Separator = styled.div`
     border-bottom: 1px solid ${COLORS.Border};

--- a/src/modals/NewStreamPermissionsModal.tsx
+++ b/src/modals/NewStreamPermissionsModal.tsx
@@ -114,7 +114,7 @@ export default function NewStreamPermissionsModal({
                         setPublicKey(value)
                         setError('')
                     }}
-                    placeholder="Public key or Ethereum address"
+                    placeholder="Hex public key or Ethereum address"
                 />
                 {!!error && (
                     <Errors theme={MarketplaceTheme} overlap>

--- a/src/modals/NewStreamPermissionsModal.tsx
+++ b/src/modals/NewStreamPermissionsModal.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react'
 import styled from 'styled-components'
-import { isAddress } from 'web3-validator'
 import { address0 } from '~/consts'
 import PermissionEditor from '~/pages/AbstractStreamEditPage/AccessControlSection/PermissionEditor'
 import { Bits, setBits, unsetBits } from '~/parsers/StreamParser'
@@ -39,6 +38,9 @@ interface NewStreamPermissionsModalProps extends FormModalProps {
     onBeforeSubmit?: (payload: PermissionBits) => void
 }
 
+const hexStringRegex = /^0x([0-9a-fA-F]{2})+$/
+const zeroAddressRegex = /^(0x)?0+$/
+
 export default function NewStreamPermissionsModal({
     onReject,
     onResolve,
@@ -65,18 +67,14 @@ export default function NewStreamPermissionsModal({
                 )
             }}
             onSubmit={() => {
-                const account = address.toLowerCase()
+                const account = `${address.startsWith('0x') ? '' : '0x'}${address.toLowerCase()}`
 
-                if (account === address0) {
-                    return void setError('Invalid address')
+                if (zeroAddressRegex.test(account)) {
+                    return void setError('Invalid key - cannot assign to zero')
                 }
 
-                if (account.length === 0) {
-                    return void setError('Address required')
-                }
-
-                if (!isAddress(account)) {
-                    return void setError('Invalid address format')
+                if (!hexStringRegex.test(account)) {
+                    return void setError('Invalid key - must be a hex string')
                 }
 
                 const result = {

--- a/src/pages/AbstractStreamEditPage/AccessControlSection/Checkbox.tsx
+++ b/src/pages/AbstractStreamEditPage/AccessControlSection/Checkbox.tsx
@@ -24,7 +24,7 @@ const Label = styled.label<LabelProps>`
 type Props = {
     operationName: string
     value: boolean
-    address: string
+    publicKey: string
     onChange: (value: boolean) => void
     disabled?: boolean
 }
@@ -32,13 +32,13 @@ type Props = {
 const Checkbox: React.FC<Props> = ({
     operationName,
     value,
-    address,
+    publicKey,
     onChange,
     disabled,
 }) => {
     const uniqueKey = useMemo(
-        () => uniqueId(`${operationName}-${address}-`),
-        [operationName, address],
+        () => uniqueId(`${operationName}-${publicKey}-`),
+        [operationName, publicKey],
     )
 
     return (

--- a/src/pages/AbstractStreamEditPage/AccessControlSection/PermissionEditor.tsx
+++ b/src/pages/AbstractStreamEditPage/AccessControlSection/PermissionEditor.tsx
@@ -33,7 +33,7 @@ const Column = styled.div`
 `
 
 type Props = {
-    address: string
+    publicKey: string
     permissionBits: number
     disabled?: boolean
     editor?: boolean
@@ -41,7 +41,7 @@ type Props = {
 }
 
 function UnstyledPermissionEditor({
-    address,
+    publicKey,
     permissionBits,
     disabled,
     onChange,
@@ -53,7 +53,7 @@ function UnstyledPermissionEditor({
                 <span>Read</span>
                 <Checkbox
                     operationName="Subscribe"
-                    address={address}
+                    publicKey={publicKey}
                     value={matchBits(Bits[StreamPermission.SUBSCRIBE], permissionBits)}
                     onChange={(value) => onChange(StreamPermission.SUBSCRIBE, value)}
                     disabled={disabled}
@@ -63,7 +63,7 @@ function UnstyledPermissionEditor({
                 <span>Write</span>
                 <Checkbox
                     operationName="Publish"
-                    address={address}
+                    publicKey={publicKey}
                     value={matchBits(Bits[StreamPermission.PUBLISH], permissionBits)}
                     onChange={(value) => onChange(StreamPermission.PUBLISH, value)}
                     disabled={disabled}
@@ -73,21 +73,21 @@ function UnstyledPermissionEditor({
                 <span>Manage</span>
                 <Checkbox
                     operationName="Grant"
-                    address={address}
+                    publicKey={publicKey}
                     value={matchBits(Bits[StreamPermission.GRANT], permissionBits)}
                     onChange={(value) => onChange(StreamPermission.GRANT, value)}
                     disabled={disabled}
                 />
                 <Checkbox
                     operationName="Edit"
-                    address={address}
+                    publicKey={publicKey}
                     value={matchBits(Bits[StreamPermission.EDIT], permissionBits)}
                     onChange={(value) => onChange(StreamPermission.EDIT, value)}
                     disabled={disabled}
                 />
                 <Checkbox
                     operationName="Delete"
-                    address={address}
+                    publicKey={publicKey}
                     value={matchBits(Bits[StreamPermission.DELETE], permissionBits)}
                     onChange={(value) => onChange(StreamPermission.DELETE, value)}
                     disabled={disabled}

--- a/src/pages/AbstractStreamEditPage/AccessControlSection/PermissionItem.tsx
+++ b/src/pages/AbstractStreamEditPage/AccessControlSection/PermissionItem.tsx
@@ -10,12 +10,12 @@ import UnstyledPermissionEditor from './PermissionEditor'
 
 type Props = {
     disabled?: boolean
-    address: string
+    publicKey: string
     permissionBits: number
 }
 
 export function PermissionItem(props: Props) {
-    const { disabled = false, address, permissionBits } = props
+    const { disabled = false, publicKey, permissionBits } = props
 
     const [isOpen, setIsOpen] = useState(false)
 
@@ -35,12 +35,12 @@ export function PermissionItem(props: Props) {
                     setIsOpen((prev) => !prev)
                 }}
             >
-                {isOpen ? address : truncate(address)}
+                {isOpen ? truncate(publicKey, 50, 20, 20) : truncate(publicKey)}
                 {isOpen ? (
                     <div />
                 ) : (
                     <Labels>
-                        {account?.toLowerCase() === address.toLowerCase() && (
+                        {account?.toLowerCase() === publicKey.toLowerCase() && (
                             <YouLabel>You</YouLabel>
                         )}
                         {operations.map((op) => (
@@ -54,16 +54,16 @@ export function PermissionItem(props: Props) {
             </Title>
             {isOpen && (
                 <PermissionEditor
-                    address={address}
+                    publicKey={publicKey}
                     permissionBits={permissionBits}
                     disabled={disabled}
                     onChange={(permission, enabled) => {
                         update((hot, cold) => {
-                            if (cold.permissions[address] == null) {
-                                cold.permissions[address] = 0
+                            if (cold.permissions[publicKey] == null) {
+                                cold.permissions[publicKey] = 0
                             }
 
-                            hot.permissions[address] = (enabled ? setBits : unsetBits)(
+                            hot.permissions[publicKey] = (enabled ? setBits : unsetBits)(
                                 permissionBits,
                                 Bits[permission],
                             )

--- a/src/pages/AbstractStreamEditPage/AccessControlSection/PermissionList.tsx
+++ b/src/pages/AbstractStreamEditPage/AccessControlSection/PermissionList.tsx
@@ -25,7 +25,7 @@ export function PermissionList({ disabled = false }) {
                     key !== address0 && (
                         <PermissionItem
                             key={key}
-                            address={key}
+                            publicKey={key}
                             permissionBits={bits || 0}
                             disabled={disabled}
                         />
@@ -33,7 +33,7 @@ export function PermissionList({ disabled = false }) {
             )}
             <Footer>
                 <span>
-                    {count} Ethereum account{count === 1 ? '' : 's'}
+                    {count} Public Key{count === 1 ? '' : 's'}
                 </span>
                 <Button
                     kind="primary"
@@ -42,36 +42,36 @@ export function PermissionList({ disabled = false }) {
                     outline
                     onClick={async () => {
                         try {
-                            const { account, bits } = await toaster(
+                            const { publicKey, bits } = await toaster(
                                 NewStreamPermissionsModal,
                                 Layer.Modal,
                             ).pop({
                                 onBeforeSubmit(payload) {
-                                    if (permissions[payload.account] != null) {
+                                    if (permissions[payload.publicKey] != null) {
                                         throw new Error(
-                                            'Permissions for this address already exist',
+                                            'Permissions for this public key already exist',
                                         )
                                     }
                                 },
                             })
 
                             update((hot, cold) => {
-                                if (cold.permissions[account] == null) {
-                                    cold.permissions[account] = 0
+                                if (cold.permissions[publicKey] == null) {
+                                    cold.permissions[publicKey] = 0
                                 }
 
-                                hot.permissions[account] = bits
+                                hot.permissions[publicKey] = bits
                             })
                         } catch (e) {
                             if (isAbandonment(e)) {
                                 return
                             }
 
-                            console.warn('Could not add permissions for a new account', e)
+                            console.warn('Could not add permissions for a new public key', e)
                         }
                     }}
                 >
-                    Add a new account
+                    Add Public Key
                 </Button>
             </Footer>
         </Container>

--- a/src/pages/AbstractStreamEditPage/AccessControlSection/StreamTypeSelector.tsx
+++ b/src/pages/AbstractStreamEditPage/AccessControlSection/StreamTypeSelector.tsx
@@ -80,7 +80,7 @@ export function StreamTypeSelector({ disabled }: Props) {
                     <div>
                         <Title>Private subscribe</Title>
                         <Description>
-                            Only Ethereum accounts listed below can read/subscribe to the
+                            Only the keys listed below can read/subscribe to the
                             stream.
                         </Description>
                     </div>

--- a/src/pages/AbstractStreamEditPage/AccessControlSection/index.tsx
+++ b/src/pages/AbstractStreamEditPage/AccessControlSection/index.tsx
@@ -17,9 +17,9 @@ export function AccessControlSection({ disabled: disabledProp = false }) {
     return (
         <Section title="Access control">
             <p>
-                You can make your stream public, or grant access to specific Ethereum
-                accounts. Learn more about stream access control from the{' '}
-                <a href={R.docs()}>docs</a>.
+                You can make your stream public, or grant access to holders of specific cryptographic keys.
+                Learn more about stream access control and permissions from the{' '}
+                <a href={R.docs('/usage/streams/permissions/')}>docs</a>.
             </p>
             <StreamTypeSelector disabled={disabled} />
             <PermissionList disabled={disabled} />

--- a/src/pages/AbstractStreamEditPage/InfoSection/index.tsx
+++ b/src/pages/AbstractStreamEditPage/InfoSection/index.tsx
@@ -48,7 +48,7 @@ export function InfoSection({ disabled: disabledProp = false }) {
                 All streams have a unique id in the format{' '}
                 <strong>domain/pathname</strong>.
                 <Surround head=" " tail=" ">
-                    The domain part can be your wallet address or an ENS name you own.
+                    The domain part can be your Ethereum address or an ENS name you own.
                 </Surround>
                 <Surround>
                     <a

--- a/src/pages/AbstractStreamEditPage/InfoSection/index.tsx
+++ b/src/pages/AbstractStreamEditPage/InfoSection/index.tsx
@@ -48,7 +48,7 @@ export function InfoSection({ disabled: disabledProp = false }) {
                 All streams have a unique id in the format{' '}
                 <strong>domain/pathname</strong>.
                 <Surround head=" " tail=" ">
-                    The domain part can be your Ethereum address or an ENS name you own.
+                    The domain part can be your wallet address or an ENS name you own.
                 </Surround>
                 <Surround>
                     <a

--- a/src/shared/utils/text.test.ts
+++ b/src/shared/utils/text.test.ts
@@ -1,8 +1,12 @@
 import { truncate, truncateStreamName, parseStreamId as psi } from './text'
 describe('text utils', () => {
     describe('truncate', () => {
-        it('does not truncate non-strings', () => {
+        it('does not truncate inputs without 0x prefix', () => {
             expect(truncate('123')).toBe('123')
+        })
+
+        it('does not truncate non-hex inputs', () => {
+            expect(truncate('0xxy')).toBe('0xxy')
         })
 
         it('does not truncate hashes that are too short', () => {
@@ -11,6 +15,21 @@ describe('text utils', () => {
             )
             expect(truncate('0x0123456789abcdef0123456789abcdef0123456')).toBe(
                 '0x0123456789abcdef0123456789abcdef0123456',
+            )
+        })
+
+        it('has configurable truncateLongerThan threshold', () => {
+            expect(truncate('0x0123456789abcdef0123456789abcdef01234567890', 100)).toBe(
+                '0x0123456789abcdef0123456789abcdef01234567890',
+            )
+            expect(truncate('0x0123456789abcdef0123456789abcdef01234567890', 40)).toBe(
+                '0x012...67890',
+            )
+        })
+
+        it('has configurable pickFirst and pickLast parameters', () => {
+            expect(truncate('0x0123456789abcdef0123456789abcdef01234567890', 40, 10, 10)).toBe(
+                '0x01234567...1234567890',
             )
         })
 

--- a/src/shared/utils/text.ts
+++ b/src/shared/utils/text.ts
@@ -1,13 +1,14 @@
-export const truncate = (path: string): string => {
-    const shortenedAddress =
-        typeof path !== 'string'
-            ? path
-            : path.replace(
-                  /0x[a-f\d]{40,}/gi,
+export const truncate = (input: string, truncateLongerThan: number = 40, pickFirst: number = 5, pickLast: number = 5): string => {
+    const regex = new RegExp(`0x[a-f\\d]{${truncateLongerThan},}`, 'gi');
+    const shortenedInput =
+        typeof input !== 'string'
+            ? input
+            : input.replace(
+                  regex,
                   (match) =>
-                      `${match.substr(0, 5)}...${match.substring(match.length - 5)}`,
-              )
-    return shortenedAddress
+                      `${match.substr(0, pickFirst)}...${match.substring(match.length - pickLast)}`,
+              );
+    return shortenedInput;
 }
 
 export function truncateNodeId(nodeId: string) {


### PR DESCRIPTION
- `NewStreamPermissionsModal` changes:
  - Allows the user to input any hex string instead of Ethereum address
  - However Grant, Edit, and Delete permission can only be given to Ethereum addresses
  - Some permissions must be checked for the submit button to be enabled
- Copy changes on stream page to replace 'account' terminology with 'keys' or 'Public Key' terminology depending on context.
- Fix overflow issue in case of long public keys (*screenshots below)
- Unrelated fix: CI was broken due to trying to start no-longer-existing `nginx` service

(*) Before:

![Screenshot 2025-05-21 at 16 57 58](https://github.com/user-attachments/assets/e7b4b185-b5f9-4a03-bb51-f87a2459eff3)

After:

![Screenshot 2025-05-21 at 16 58 08](https://github.com/user-attachments/assets/45228946-b1ae-400c-9da0-24f9e76f05a3)
