### PR TITLE
remove logstore from chain config

### DIFF
--- a/src/config/chains.toml
+++ b/src/config/chains.toml
@@ -59,11 +59,6 @@ streamIndexerUrl = "https://stream-metrics.streamr.network/api"
 name = "Streamr Germany"
 address = "0x31546eEA76F2B2b3C5cC06B1c93601dc35c9D916"
 
-[[polygon.storageNodes]]
-name = "LogStore Decentralized Storage"
-address = "0x17f98084757a75add72bf6c5b5a6f69008c28a57"
-thirdPartyUrl = "https://docs.usher.so/logstore/network/specifics/overview#streamr-storage-provider"
-
 [[polygon.dataunionGraphNames]]
 chainId = 100
 name = "dataunions/data-unions-gnosis"


### PR DESCRIPTION
Dear Streamr Team,

I hope this message finds you well.

I am writing on behalf of Usher Labs to inform you that we are deprecating our Log Store Decentralised Storage Network. The full codebase is open source and available for adoption, inheritance, or utilisation by the Streamr team, whether for commercial or experimental purposes. Licenses can be updated accordingly.
Documentation and source code for the Log Store will remain accessible at: 
- https://docs.logstore.usher.so/
- https://github.com/usherlabs/logstore
- https://github.com/usherlabs/logstore-node

Should the Streamr team decide to inherit or continue development of the Log Store technology, Usher Labs is fully prepared to hand over the complete documentation and assist with the transition.

We truly appreciate the collaboration and shared experimentation in the field of decentralised storage over the years. We sincerely hope the Log Store technology can find a new home, where ongoing maintenance and development can be prioritised.

Thank you for your time and consideration. Please feel free to reach out if you’d like to discuss this further.

Best regards,
Ryan
Usher Labs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small configuration-only change that just removes a deprecated third-party endpoint; risk is limited to Polygon storage node selection/availability if anything still relied on that entry.
> 
> **Overview**
> Removes the third-party **LogStore Decentralized Storage** entry from `polygon.storageNodes` in `src/config/chains.toml`, leaving only the Streamr-operated storage node for Polygon.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60da117817b935fc7bdc99a7f9d1a84e29db77bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->